### PR TITLE
fix: Prism inline colour (by removal!)

### DIFF
--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -1,0 +1,126 @@
+/*
+ * ATTENTION: The "eval" devtool has been used (maybe by default in mode: "development").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses "eval()" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with "devtool: false".
+ * If you are looking for production-ready output files, see mode: "production" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => { // webpackBootstrap
+/******/ 	"use strict";
+/******/ 	var __webpack_modules__ = ({
+
+/***/ "./src/editor.js":
+/*!***********************!*\
+  !*** ./src/editor.js ***!
+  \***********************/
+/***/ ((__unused_webpack___webpack_module__, __webpack_exports__, __webpack_require__) => {
+
+eval("__webpack_require__.r(__webpack_exports__);\n/* harmony export */ __webpack_require__.d(__webpack_exports__, {\n/* harmony export */   \"updateOutput\": () => (/* binding */ updateOutput),\n/* harmony export */   \"initInput\": () => (/* binding */ initInput)\n/* harmony export */ });\nconst onMessage = () => {\n  return `window.addEventListener('message', (event) => {\n            const newStyle = document.createElement('style');\n            newStyle.textContent = event.data;\n            document.head.append(newStyle);\n\n            const styleTags = document.querySelectorAll('style');\n            styleTags[0].parentNode.removeChild(styleTags[0]);\n        }\n      )`;\n};\n\n/* https://stackoverflow.com/a/61421435 */\nconst updateOutput = (iframe, css, html) => {\n  const iframeHTML = `\n    <!doctype html>\n    <html>\n      <head>\n        <style>${css}</style>\n        <link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css\">\n      </head>\n      <body>\n        ${html}\n        <script>\n          ${onMessage()}\n        </script>\n      </body>\n    </html>`;\n  iframe.src = 'data:text/html,' + encodeURIComponent(iframeHTML);\n};\n\nconst initInput = (UI, CHALLENGE) => {\n  UI.inputTextarea.addEventListener('input', (event) => {\n    let userCSS = UI.inputTextarea.value;\n\n    // Fixing bug with scrolling aligning (pre/code otherwise ignore empty final new lines)\n    if (userCSS[userCSS.length-1] == \"\\n\") {\n      userCSS += \" \";\n    }\n\n    UI.inputCode.innerHTML = Prism.highlight(userCSS, Prism.languages.css, 'css');\n\n    UI.outputUser.contentWindow.postMessage(userCSS, \"*\");\n  });\n\n  UI.inputTextarea.addEventListener('scroll', (event) => {\n    UI.inputPre.scrollTop  = UI.inputTextarea.scrollTop;\n    UI.inputPre.scrollLeft = UI.inputTextarea.scrollLeft;\n  });\n};\n\n\n//# sourceURL=webpack://css_target_practice/./src/editor.js?");
+
+/***/ }),
+
+/***/ "./src/index.js":
+/*!**********************!*\
+  !*** ./src/index.js ***!
+  \**********************/
+/***/ ((__unused_webpack___webpack_module__, __webpack_exports__, __webpack_require__) => {
+
+eval("__webpack_require__.r(__webpack_exports__);\n/* harmony import */ var _editor_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./editor.js */ \"./src/editor.js\");\n/* harmony import */ var _menu_js__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./menu.js */ \"./src/menu.js\");\n/* harmony import */ var _resize_js__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ./resize.js */ \"./src/resize.js\");\n/* harmony import */ var _tabs_js__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! ./tabs.js */ \"./src/tabs.js\");\n\n\n\n\n\nconst UI = {\n  header: document.querySelector('header'),\n  h1: document.querySelector('h1'),\n\n  menuDiv: document.getElementById('menu'),\n  loading: document.getElementById('loading'),\n  loadError: document.getElementById('load-error'),\n  challengeForm: document.getElementById('challenge-form'),\n  challengeSelect: document.getElementById('challenge-select'),\n\n  challengeDiv: document.getElementById('challenge'),\n  htmlCode: document.getElementById('html-code'),\n  inputTextarea: document.getElementById('input-textarea'),\n  inputPre: document.getElementById('input-pre'),\n  inputCode: document.getElementById('input-code'),\n\n  outputTarget: document.getElementById('output-target'),\n  outputUser: document.getElementById('output-user')\n};\n\nconst CHALLENGE = {};\n\n/*\n * Adds input listener to inputTextarea to update outputUser\n * Adds scroll listener to inputTextarea to line up inputCode and inputPre\n*/\n(0,_editor_js__WEBPACK_IMPORTED_MODULE_0__.initInput)(UI, CHALLENGE);\n/*\n * Populates the <select> with <option>s based on the API\n   and adds an Event listener to display chosen challenge\n*/\n(0,_menu_js__WEBPACK_IMPORTED_MODULE_1__.initMenu)(UI, CHALLENGE);\n/*\n * Adds an Event listener to allow users to adjust\n   the relative widths of the input and output\n*/\n(0,_resize_js__WEBPACK_IMPORTED_MODULE_2__.initResizeable)();\n/*\n * Add Event listeners so users can change input/output displays\n   eg: switch from seeing html-code to input-code\n*/\n(0,_tabs_js__WEBPACK_IMPORTED_MODULE_3__.initTabs)();\n\n\n//# sourceURL=webpack://css_target_practice/./src/index.js?");
+
+/***/ }),
+
+/***/ "./src/menu.js":
+/*!*********************!*\
+  !*** ./src/menu.js ***!
+  \*********************/
+/***/ ((__unused_webpack___webpack_module__, __webpack_exports__, __webpack_require__) => {
+
+eval("__webpack_require__.r(__webpack_exports__);\n/* harmony export */ __webpack_require__.d(__webpack_exports__, {\n/* harmony export */   \"initMenu\": () => (/* binding */ initMenu)\n/* harmony export */ });\n/* harmony import */ var _editor_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./editor.js */ \"./src/editor.js\");\n\n\nconst loadChallenges = async () => {\n  const response = await fetch('http://localhost:3000/challenges');\n  const data = await response.json();\n\n  return data;\n};\n\nconst onLoadFail = (UI) => {\n  UI.loading.classList.remove('display-block');\n  UI.challengeForm.classList.remove('display-block');\n\n  UI.loadError.classList.add('display-block');\n};\n\nconst buildMenu = (data, UI) => {\n  data.forEach((challenge) => {\n    UI.challengeSelect.insertAdjacentHTML('beforeend', `<option value=${challenge.id}>${challenge.name}</option>`);\n  })\n\n  UI.loading.classList.remove('display-block');\n  UI.challengeForm.classList.add('display-block');\n};\n\nconst populateMenu = async (UI) => {\n  let data = [];\n\n  try {\n    data = await loadChallenges();\n  } catch(e) {\n    onLoadFail(UI);\n    return;\n  }\n\n  buildMenu(data, UI);\n};\n\n/**\n * Retrieves the challenge selected by the user\n * @see onFormSubmit()\n*/\nconst loadChallenge = async (UI) => {\n  const response = await fetch(`http://localhost:3000/challenges/${UI.challengeSelect.value}`);\n  const data = await response.json();\n\n  return data;\n};\n\nconst setupChallenge = (newChallenge, UI, CHALLENGE) => {\n  CHALLENGE.html = newChallenge.html;\n  CHALLENGE.css = newChallenge.css;\n\n  UI.htmlCode.innerHTML = Prism.highlight(CHALLENGE.html, Prism.languages.html, 'html');\n\n  UI.inputTextarea.value = '';\n  UI.inputCode.innerHTML = '';\n\n  (0,_editor_js__WEBPACK_IMPORTED_MODULE_0__.updateOutput)(UI.outputTarget, CHALLENGE.css, CHALLENGE.html);\n  (0,_editor_js__WEBPACK_IMPORTED_MODULE_0__.updateOutput)(UI.outputUser, ' ', CHALLENGE.html);\n};\n\nconst displayChallenge = (UI) => {\n  UI.header.classList.add('challenge');\n\n  UI.menuDiv.classList.remove('display-flex');\n  UI.challengeDiv.classList.add('display-flex');\n};\n\n/**\n * @param {Event} event - The submit event from addEventListener\n*/\nconst onFormSubmit = async (UI, CHALLENGE, event) => {\n  // Need to prevent default form submission behaviour\n  event.preventDefault();\n\n  let newChallenge;\n  try {\n    newChallenge = await loadChallenge(UI);\n  } catch(e) {\n    onLoadFail(UI);\n    return;\n  }\n\n  setupChallenge(newChallenge, UI, CHALLENGE);\n  displayChallenge(UI);\n};\n\nconst resetTabsDisplayed = () => {\n  const event = new MouseEvent('click', {\n    view: window,\n    bubbles: true,\n    cancelable: true\n  });\n\n  document.querySelector('[data-tab-target=\"#challenge-html\"]').dispatchEvent(event);\n  document.querySelector('[data-tab-target=\"#output-target\"]').dispatchEvent(event);\n};\n\nconst onH1Click = (UI) => {\n  UI.header.classList.remove('challenge');\n\n  UI.menuDiv.classList.add('display-flex');\n  UI.challengeDiv.classList.remove('display-flex');\n\n  resetTabsDisplayed();\n};\n\nconst initMenu = (UI, CHALLENGE) => {\n  populateMenu(UI);\n  UI.challengeForm.addEventListener('submit', onFormSubmit.bind(null, UI, CHALLENGE));\n  UI.h1.addEventListener('click', onH1Click.bind(null, UI));\n};\n\n\n//# sourceURL=webpack://css_target_practice/./src/menu.js?");
+
+/***/ }),
+
+/***/ "./src/resize.js":
+/*!***********************!*\
+  !*** ./src/resize.js ***!
+  \***********************/
+/***/ ((__unused_webpack___webpack_module__, __webpack_exports__, __webpack_require__) => {
+
+eval("__webpack_require__.r(__webpack_exports__);\n/* harmony export */ __webpack_require__.d(__webpack_exports__, {\n/* harmony export */   \"initResizeable\": () => (/* binding */ initResizeable)\n/* harmony export */ });\n// Adapted from https://htmldom.dev/create-resizable-split-views/\n\nconst resizer   = document.getElementById('resizer');\nconst leftSide  = document.getElementById('input');\nconst rightSide = document.getElementById('output');\n\n// These are for the position of the mouse\nlet x = 0;\nlet y = 0;\n\nlet leftWidth = 0;\n\nconst mouseMoveHandler = e => {\n  // How far the mouse has been moved\n  const dx = e.clientX - x;\n  const dy = e.clientY - y;\n\n  const newResizerLeft = resizer.offsetLeft + dx;\n  resizer.style.left = `${newResizerLeft}px`;\n\n  const newLeftWidth = newResizerLeft * 100 / resizer.parentNode.getBoundingClientRect().width;\n  leftWidth = newLeftWidth;\n  leftSide.style.width = `${newLeftWidth}%`;\n\n  leftSide.style.userSelect = 'none';\n  leftSide.style.pointerEvents = 'none';\n\n  rightSide.style.userSelect = 'none';\n  rightSide.style.pointerEvents = 'none';\n\n  resizer.style.cursor = 'col-resize';\n  document.body.style.cursor = 'col-resize';\n\n  x = e.clientX;\n  y = e.clientY;\n};\n\nconst mouseUpHandler = () => {\n  resizer.style.removeProperty('cursor');\n  document.body.style.removeProperty('cursor');\n\n  leftSide.style.removeProperty('user-select');\n  leftSide.style.removeProperty('pointer-events');\n\n  rightSide.style.removeProperty('user-select');\n  rightSide.style.removeProperty('pointer-events');\n\n  // Remove the handlers of `mousemove` and `mouseup`\n  document.removeEventListener('mousemove', mouseMoveHandler);\n  document.removeEventListener('mouseup', mouseUpHandler);\n};\n\nconst mouseDownHandler = e => {\n  // Get the current mouse position\n  x = e.clientX;\n  y = e.clientY;\n  leftWidth = leftSide.getBoundingClientRect().width;\n\n  document.addEventListener('mousemove', mouseMoveHandler);\n  document.addEventListener('mouseup', mouseUpHandler);\n};\n\n// Wrap the addEventListener in a function so we can call it from ./index.js\nconst initResizeable = () => {\n  resizer.addEventListener('mousedown', mouseDownHandler);\n}\n\n\n//# sourceURL=webpack://css_target_practice/./src/resize.js?");
+
+/***/ }),
+
+/***/ "./src/tabs.js":
+/*!*********************!*\
+  !*** ./src/tabs.js ***!
+  \*********************/
+/***/ ((__unused_webpack___webpack_module__, __webpack_exports__, __webpack_require__) => {
+
+eval("__webpack_require__.r(__webpack_exports__);\n/* harmony export */ __webpack_require__.d(__webpack_exports__, {\n/* harmony export */   \"initTabs\": () => (/* binding */ initTabs)\n/* harmony export */ });\n/* Based on method used in https://www.youtube.com/watch?v=5L6h_MrNvsk by Web Dev Simplified */\nconst tabs = document.querySelectorAll('[data-tab-target]');\n\nconst onClick = (event) => {\n  const target = event.target;\n\n  // Hide currently displayed content\n  const oldContent = document.querySelector(`${target.dataset.tabType} .display-block`);\n  if (oldContent) { oldContent.classList.remove('display-block'); }\n\n  // Display desired content\n  const newContent = document.querySelector(target.dataset.tabTarget);\n  newContent.classList.add('display-block');\n\n  // Remove active styling from link for previous content\n  const oldTab = document.querySelector(`${target.dataset.tabType} .active-tab`);\n  if (oldTab) { oldTab.classList.remove('active-tab'); }\n\n  // Add active styling to link for desired content\n  target.classList.add('active-tab');\n};\n\nconst initTabs = () => {\n  tabs.forEach(tab => { tab.addEventListener('click', onClick); })\n};\n\n\n//# sourceURL=webpack://css_target_practice/./src/tabs.js?");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	var __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/define property getters */
+/******/ 	(() => {
+/******/ 		// define getter functions for harmony exports
+/******/ 		__webpack_require__.d = (exports, definition) => {
+/******/ 			for(var key in definition) {
+/******/ 				if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 					Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 				}
+/******/ 			}
+/******/ 		};
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/hasOwnProperty shorthand */
+/******/ 	(() => {
+/******/ 		__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/make namespace object */
+/******/ 	(() => {
+/******/ 		// define __esModule on exports
+/******/ 		__webpack_require__.r = (exports) => {
+/******/ 			if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+/******/ 				Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+/******/ 			}
+/******/ 			Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 		};
+/******/ 	})();
+/******/ 	
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval devtool is used.
+/******/ 	var __webpack_exports__ = __webpack_require__("./src/index.js");
+/******/ 	
+/******/ })()
+;

--- a/src/prism/prism.js
+++ b/src/prism/prism.js
@@ -1,14 +1,14 @@
-/* PrismJS 1.24.1
-https://prismjs.com/download.html#themes=prism-tomorrow&languages=markup+css+css-extras&plugins=inline-color+match-braces */
+/* PrismJS 1.25.0
+https://prismjs.com/download.html#themes=prism-tomorrow&languages=markup+css+css-extras&plugins=match-braces */
 /// <reference lib="WebWorker"/>
 
 var _self = (typeof window !== 'undefined')
-	? window   // if in browser
-	: (
-		(typeof WorkerGlobalScope !== 'undefined' && self instanceof WorkerGlobalScope)
-			? self // if in worker
-			: {}   // if in node js
-	);
+  ? window   // if in browser
+  : (
+    (typeof WorkerGlobalScope !== 'undefined' && self instanceof WorkerGlobalScope)
+      ? self // if in worker
+      : {}   // if in node js
+  );
 
 /**
  * Prism: Lightweight, robust, elegant syntax highlighting
@@ -20,1157 +20,1196 @@ var _self = (typeof window !== 'undefined')
  */
 var Prism = (function (_self) {
 
-	// Private helper vars
-	var lang = /\blang(?:uage)?-([\w-]+)\b/i;
-	var uniqueId = 0;
-
-	// The grammar object for plaintext
-	var plainTextGrammar = {};
-
-
-	var _ = {
-		/**
-		 * By default, Prism will attempt to highlight all code elements (by calling {@link Prism.highlightAll}) on the
-		 * current page after the page finished loading. This might be a problem if e.g. you wanted to asynchronously load
-		 * additional languages or plugins yourself.
-		 *
-		 * By setting this value to `true`, Prism will not automatically highlight all code elements on the page.
-		 *
-		 * You obviously have to change this value before the automatic highlighting started. To do this, you can add an
-		 * empty Prism object into the global scope before loading the Prism script like this:
-		 *
-		 * ```js
-		 * window.Prism = window.Prism || {};
-		 * Prism.manual = true;
-		 * // add a new <script> to load Prism's script
-		 * ```
-		 *
-		 * @default false
-		 * @type {boolean}
-		 * @memberof Prism
-		 * @public
-		 */
-		manual: _self.Prism && _self.Prism.manual,
-		disableWorkerMessageHandler: _self.Prism && _self.Prism.disableWorkerMessageHandler,
-
-		/**
-		 * A namespace for utility methods.
-		 *
-		 * All function in this namespace that are not explicitly marked as _public_ are for __internal use only__ and may
-		 * change or disappear at any time.
-		 *
-		 * @namespace
-		 * @memberof Prism
-		 */
-		util: {
-			encode: function encode(tokens) {
-				if (tokens instanceof Token) {
-					return new Token(tokens.type, encode(tokens.content), tokens.alias);
-				} else if (Array.isArray(tokens)) {
-					return tokens.map(encode);
-				} else {
-					return tokens.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/\u00a0/g, ' ');
-				}
-			},
-
-			/**
-			 * Returns the name of the type of the given value.
-			 *
-			 * @param {any} o
-			 * @returns {string}
-			 * @example
-			 * type(null)      === 'Null'
-			 * type(undefined) === 'Undefined'
-			 * type(123)       === 'Number'
-			 * type('foo')     === 'String'
-			 * type(true)      === 'Boolean'
-			 * type([1, 2])    === 'Array'
-			 * type({})        === 'Object'
-			 * type(String)    === 'Function'
-			 * type(/abc+/)    === 'RegExp'
-			 */
-			type: function (o) {
-				return Object.prototype.toString.call(o).slice(8, -1);
-			},
-
-			/**
-			 * Returns a unique number for the given object. Later calls will still return the same number.
-			 *
-			 * @param {Object} obj
-			 * @returns {number}
-			 */
-			objId: function (obj) {
-				if (!obj['__id']) {
-					Object.defineProperty(obj, '__id', { value: ++uniqueId });
-				}
-				return obj['__id'];
-			},
-
-			/**
-			 * Creates a deep clone of the given object.
-			 *
-			 * The main intended use of this function is to clone language definitions.
-			 *
-			 * @param {T} o
-			 * @param {Record<number, any>} [visited]
-			 * @returns {T}
-			 * @template T
-			 */
-			clone: function deepClone(o, visited) {
-				visited = visited || {};
-
-				var clone; var id;
-				switch (_.util.type(o)) {
-					case 'Object':
-						id = _.util.objId(o);
-						if (visited[id]) {
-							return visited[id];
-						}
-						clone = /** @type {Record<string, any>} */ ({});
-						visited[id] = clone;
-
-						for (var key in o) {
-							if (o.hasOwnProperty(key)) {
-								clone[key] = deepClone(o[key], visited);
-							}
-						}
-
-						return /** @type {any} */ (clone);
-
-					case 'Array':
-						id = _.util.objId(o);
-						if (visited[id]) {
-							return visited[id];
-						}
-						clone = [];
-						visited[id] = clone;
-
-						(/** @type {Array} */(/** @type {any} */(o))).forEach(function (v, i) {
-							clone[i] = deepClone(v, visited);
-						});
-
-						return /** @type {any} */ (clone);
-
-					default:
-						return o;
-				}
-			},
-
-			/**
-			 * Returns the Prism language of the given element set by a `language-xxxx` or `lang-xxxx` class.
-			 *
-			 * If no language is set for the element or the element is `null` or `undefined`, `none` will be returned.
-			 *
-			 * @param {Element} element
-			 * @returns {string}
-			 */
-			getLanguage: function (element) {
-				while (element && !lang.test(element.className)) {
-					element = element.parentElement;
-				}
-				if (element) {
-					return (element.className.match(lang) || [, 'none'])[1].toLowerCase();
-				}
-				return 'none';
-			},
-
-			/**
-			 * Returns the script element that is currently executing.
-			 *
-			 * This does __not__ work for line script element.
-			 *
-			 * @returns {HTMLScriptElement | null}
-			 */
-			currentScript: function () {
-				if (typeof document === 'undefined') {
-					return null;
-				}
-				if ('currentScript' in document && 1 < 2 /* hack to trip TS' flow analysis */) {
-					return /** @type {any} */ (document.currentScript);
-				}
-
-				// IE11 workaround
-				// we'll get the src of the current script by parsing IE11's error stack trace
-				// this will not work for inline scripts
-
-				try {
-					throw new Error();
-				} catch (err) {
-					// Get file src url from stack. Specifically works with the format of stack traces in IE.
-					// A stack will look like this:
-					//
-					// Error
-					//    at _.util.currentScript (http://localhost/components/prism-core.js:119:5)
-					//    at Global code (http://localhost/components/prism-core.js:606:1)
-
-					var src = (/at [^(\r\n]*\((.*):.+:.+\)$/i.exec(err.stack) || [])[1];
-					if (src) {
-						var scripts = document.getElementsByTagName('script');
-						for (var i in scripts) {
-							if (scripts[i].src == src) {
-								return scripts[i];
-							}
-						}
-					}
-					return null;
-				}
-			},
-
-			/**
-			 * Returns whether a given class is active for `element`.
-			 *
-			 * The class can be activated if `element` or one of its ancestors has the given class and it can be deactivated
-			 * if `element` or one of its ancestors has the negated version of the given class. The _negated version_ of the
-			 * given class is just the given class with a `no-` prefix.
-			 *
-			 * Whether the class is active is determined by the closest ancestor of `element` (where `element` itself is
-			 * closest ancestor) that has the given class or the negated version of it. If neither `element` nor any of its
-			 * ancestors have the given class or the negated version of it, then the default activation will be returned.
-			 *
-			 * In the paradoxical situation where the closest ancestor contains __both__ the given class and the negated
-			 * version of it, the class is considered active.
-			 *
-			 * @param {Element} element
-			 * @param {string} className
-			 * @param {boolean} [defaultActivation=false]
-			 * @returns {boolean}
-			 */
-			isActive: function (element, className, defaultActivation) {
-				var no = 'no-' + className;
-
-				while (element) {
-					var classList = element.classList;
-					if (classList.contains(className)) {
-						return true;
-					}
-					if (classList.contains(no)) {
-						return false;
-					}
-					element = element.parentElement;
-				}
-				return !!defaultActivation;
-			}
-		},
-
-		/**
-		 * This namespace contains all currently loaded languages and the some helper functions to create and modify languages.
-		 *
-		 * @namespace
-		 * @memberof Prism
-		 * @public
-		 */
-		languages: {
-			/**
-			 * The grammar for plain, unformatted text.
-			 */
-			plain: plainTextGrammar,
-			plaintext: plainTextGrammar,
-			text: plainTextGrammar,
-			txt: plainTextGrammar,
-
-			/**
-			 * Creates a deep copy of the language with the given id and appends the given tokens.
-			 *
-			 * If a token in `redef` also appears in the copied language, then the existing token in the copied language
-			 * will be overwritten at its original position.
-			 *
-			 * ## Best practices
-			 *
-			 * Since the position of overwriting tokens (token in `redef` that overwrite tokens in the copied language)
-			 * doesn't matter, they can technically be in any order. However, this can be confusing to others that trying to
-			 * understand the language definition because, normally, the order of tokens matters in Prism grammars.
-			 *
-			 * Therefore, it is encouraged to order overwriting tokens according to the positions of the overwritten tokens.
-			 * Furthermore, all non-overwriting tokens should be placed after the overwriting ones.
-			 *
-			 * @param {string} id The id of the language to extend. This has to be a key in `Prism.languages`.
-			 * @param {Grammar} redef The new tokens to append.
-			 * @returns {Grammar} The new language created.
-			 * @public
-			 * @example
-			 * Prism.languages['css-with-colors'] = Prism.languages.extend('css', {
-			 *     // Prism.languages.css already has a 'comment' token, so this token will overwrite CSS' 'comment' token
-			 *     // at its original position
-			 *     'comment': { ... },
-			 *     // CSS doesn't have a 'color' token, so this token will be appended
-			 *     'color': /\b(?:red|green|blue)\b/
-			 * });
-			 */
-			extend: function (id, redef) {
-				var lang = _.util.clone(_.languages[id]);
-
-				for (var key in redef) {
-					lang[key] = redef[key];
-				}
-
-				return lang;
-			},
-
-			/**
-			 * Inserts tokens _before_ another token in a language definition or any other grammar.
-			 *
-			 * ## Usage
-			 *
-			 * This helper method makes it easy to modify existing languages. For example, the CSS language definition
-			 * not only defines CSS highlighting for CSS documents, but also needs to define highlighting for CSS embedded
-			 * in HTML through `<style>` elements. To do this, it needs to modify `Prism.languages.markup` and add the
-			 * appropriate tokens. However, `Prism.languages.markup` is a regular JavaScript object literal, so if you do
-			 * this:
-			 *
-			 * ```js
-			 * Prism.languages.markup.style = {
-			 *     // token
-			 * };
-			 * ```
-			 *
-			 * then the `style` token will be added (and processed) at the end. `insertBefore` allows you to insert tokens
-			 * before existing tokens. For the CSS example above, you would use it like this:
-			 *
-			 * ```js
-			 * Prism.languages.insertBefore('markup', 'cdata', {
-			 *     'style': {
-			 *         // token
-			 *     }
-			 * });
-			 * ```
-			 *
-			 * ## Special cases
-			 *
-			 * If the grammars of `inside` and `insert` have tokens with the same name, the tokens in `inside`'s grammar
-			 * will be ignored.
-			 *
-			 * This behavior can be used to insert tokens after `before`:
-			 *
-			 * ```js
-			 * Prism.languages.insertBefore('markup', 'comment', {
-			 *     'comment': Prism.languages.markup.comment,
-			 *     // tokens after 'comment'
-			 * });
-			 * ```
-			 *
-			 * ## Limitations
-			 *
-			 * The main problem `insertBefore` has to solve is iteration order. Since ES2015, the iteration order for object
-			 * properties is guaranteed to be the insertion order (except for integer keys) but some browsers behave
-			 * differently when keys are deleted and re-inserted. So `insertBefore` can't be implemented by temporarily
-			 * deleting properties which is necessary to insert at arbitrary positions.
-			 *
-			 * To solve this problem, `insertBefore` doesn't actually insert the given tokens into the target object.
-			 * Instead, it will create a new object and replace all references to the target object with the new one. This
-			 * can be done without temporarily deleting properties, so the iteration order is well-defined.
-			 *
-			 * However, only references that can be reached from `Prism.languages` or `insert` will be replaced. I.e. if
-			 * you hold the target object in a variable, then the value of the variable will not change.
-			 *
-			 * ```js
-			 * var oldMarkup = Prism.languages.markup;
-			 * var newMarkup = Prism.languages.insertBefore('markup', 'comment', { ... });
-			 *
-			 * assert(oldMarkup !== Prism.languages.markup);
-			 * assert(newMarkup === Prism.languages.markup);
-			 * ```
-			 *
-			 * @param {string} inside The property of `root` (e.g. a language id in `Prism.languages`) that contains the
-			 * object to be modified.
-			 * @param {string} before The key to insert before.
-			 * @param {Grammar} insert An object containing the key-value pairs to be inserted.
-			 * @param {Object<string, any>} [root] The object containing `inside`, i.e. the object that contains the
-			 * object to be modified.
-			 *
-			 * Defaults to `Prism.languages`.
-			 * @returns {Grammar} The new grammar object.
-			 * @public
-			 */
-			insertBefore: function (inside, before, insert, root) {
-				root = root || /** @type {any} */ (_.languages);
-				var grammar = root[inside];
-				/** @type {Grammar} */
-				var ret = {};
-
-				for (var token in grammar) {
-					if (grammar.hasOwnProperty(token)) {
-
-						if (token == before) {
-							for (var newToken in insert) {
-								if (insert.hasOwnProperty(newToken)) {
-									ret[newToken] = insert[newToken];
-								}
-							}
-						}
-
-						// Do not insert token which also occur in insert. See #1525
-						if (!insert.hasOwnProperty(token)) {
-							ret[token] = grammar[token];
-						}
-					}
-				}
-
-				var old = root[inside];
-				root[inside] = ret;
-
-				// Update references in other language definitions
-				_.languages.DFS(_.languages, function (key, value) {
-					if (value === old && key != inside) {
-						this[key] = ret;
-					}
-				});
-
-				return ret;
-			},
-
-			// Traverse a language definition with Depth First Search
-			DFS: function DFS(o, callback, type, visited) {
-				visited = visited || {};
-
-				var objId = _.util.objId;
-
-				for (var i in o) {
-					if (o.hasOwnProperty(i)) {
-						callback.call(o, i, o[i], type || i);
-
-						var property = o[i];
-						var propertyType = _.util.type(property);
-
-						if (propertyType === 'Object' && !visited[objId(property)]) {
-							visited[objId(property)] = true;
-							DFS(property, callback, null, visited);
-						} else if (propertyType === 'Array' && !visited[objId(property)]) {
-							visited[objId(property)] = true;
-							DFS(property, callback, i, visited);
-						}
-					}
-				}
-			}
-		},
-
-		plugins: {},
-
-		/**
-		 * This is the most high-level function in Prism’s API.
-		 * It fetches all the elements that have a `.language-xxxx` class and then calls {@link Prism.highlightElement} on
-		 * each one of them.
-		 *
-		 * This is equivalent to `Prism.highlightAllUnder(document, async, callback)`.
-		 *
-		 * @param {boolean} [async=false] Same as in {@link Prism.highlightAllUnder}.
-		 * @param {HighlightCallback} [callback] Same as in {@link Prism.highlightAllUnder}.
-		 * @memberof Prism
-		 * @public
-		 */
-		highlightAll: function (async, callback) {
-			_.highlightAllUnder(document, async, callback);
-		},
-
-		/**
-		 * Fetches all the descendants of `container` that have a `.language-xxxx` class and then calls
-		 * {@link Prism.highlightElement} on each one of them.
-		 *
-		 * The following hooks will be run:
-		 * 1. `before-highlightall`
-		 * 2. `before-all-elements-highlight`
-		 * 3. All hooks of {@link Prism.highlightElement} for each element.
-		 *
-		 * @param {ParentNode} container The root element, whose descendants that have a `.language-xxxx` class will be highlighted.
-		 * @param {boolean} [async=false] Whether each element is to be highlighted asynchronously using Web Workers.
-		 * @param {HighlightCallback} [callback] An optional callback to be invoked on each element after its highlighting is done.
-		 * @memberof Prism
-		 * @public
-		 */
-		highlightAllUnder: function (container, async, callback) {
-			var env = {
-				callback: callback,
-				container: container,
-				selector: 'code[class*="language-"], [class*="language-"] code, code[class*="lang-"], [class*="lang-"] code'
-			};
-
-			_.hooks.run('before-highlightall', env);
-
-			env.elements = Array.prototype.slice.apply(env.container.querySelectorAll(env.selector));
-
-			_.hooks.run('before-all-elements-highlight', env);
-
-			for (var i = 0, element; (element = env.elements[i++]);) {
-				_.highlightElement(element, async === true, env.callback);
-			}
-		},
-
-		/**
-		 * Highlights the code inside a single element.
-		 *
-		 * The following hooks will be run:
-		 * 1. `before-sanity-check`
-		 * 2. `before-highlight`
-		 * 3. All hooks of {@link Prism.highlight}. These hooks will be run by an asynchronous worker if `async` is `true`.
-		 * 4. `before-insert`
-		 * 5. `after-highlight`
-		 * 6. `complete`
-		 *
-		 * Some the above hooks will be skipped if the element doesn't contain any text or there is no grammar loaded for
-		 * the element's language.
-		 *
-		 * @param {Element} element The element containing the code.
-		 * It must have a class of `language-xxxx` to be processed, where `xxxx` is a valid language identifier.
-		 * @param {boolean} [async=false] Whether the element is to be highlighted asynchronously using Web Workers
-		 * to improve performance and avoid blocking the UI when highlighting very large chunks of code. This option is
-		 * [disabled by default](https://prismjs.com/faq.html#why-is-asynchronous-highlighting-disabled-by-default).
-		 *
-		 * Note: All language definitions required to highlight the code must be included in the main `prism.js` file for
-		 * asynchronous highlighting to work. You can build your own bundle on the
-		 * [Download page](https://prismjs.com/download.html).
-		 * @param {HighlightCallback} [callback] An optional callback to be invoked after the highlighting is done.
-		 * Mostly useful when `async` is `true`, since in that case, the highlighting is done asynchronously.
-		 * @memberof Prism
-		 * @public
-		 */
-		highlightElement: function (element, async, callback) {
-			// Find language
-			var language = _.util.getLanguage(element);
-			var grammar = _.languages[language];
-
-			// Set language on the element, if not present
-			element.className = element.className.replace(lang, '').replace(/\s+/g, ' ') + ' language-' + language;
-
-			// Set language on the parent, for styling
-			var parent = element.parentElement;
-			if (parent && parent.nodeName.toLowerCase() === 'pre') {
-				parent.className = parent.className.replace(lang, '').replace(/\s+/g, ' ') + ' language-' + language;
-			}
-
-			var code = element.textContent;
-
-			var env = {
-				element: element,
-				language: language,
-				grammar: grammar,
-				code: code
-			};
-
-			function insertHighlightedCode(highlightedCode) {
-				env.highlightedCode = highlightedCode;
-
-				_.hooks.run('before-insert', env);
-
-				env.element.innerHTML = env.highlightedCode;
-
-				_.hooks.run('after-highlight', env);
-				_.hooks.run('complete', env);
-				callback && callback.call(env.element);
-			}
-
-			_.hooks.run('before-sanity-check', env);
-
-			// plugins may change/add the parent/element
-			parent = env.element.parentElement;
-			if (parent && parent.nodeName.toLowerCase() === 'pre' && !parent.hasAttribute('tabindex')) {
-				parent.setAttribute('tabindex', '0');
-			}
-
-			if (!env.code) {
-				_.hooks.run('complete', env);
-				callback && callback.call(env.element);
-				return;
-			}
-
-			_.hooks.run('before-highlight', env);
-
-			if (!env.grammar) {
-				insertHighlightedCode(_.util.encode(env.code));
-				return;
-			}
-
-			if (async && _self.Worker) {
-				var worker = new Worker(_.filename);
-
-				worker.onmessage = function (evt) {
-					insertHighlightedCode(evt.data);
-				};
-
-				worker.postMessage(JSON.stringify({
-					language: env.language,
-					code: env.code,
-					immediateClose: true
-				}));
-			} else {
-				insertHighlightedCode(_.highlight(env.code, env.grammar, env.language));
-			}
-		},
-
-		/**
-		 * Low-level function, only use if you know what you’re doing. It accepts a string of text as input
-		 * and the language definitions to use, and returns a string with the HTML produced.
-		 *
-		 * The following hooks will be run:
-		 * 1. `before-tokenize`
-		 * 2. `after-tokenize`
-		 * 3. `wrap`: On each {@link Token}.
-		 *
-		 * @param {string} text A string with the code to be highlighted.
-		 * @param {Grammar} grammar An object containing the tokens to use.
-		 *
-		 * Usually a language definition like `Prism.languages.markup`.
-		 * @param {string} language The name of the language definition passed to `grammar`.
-		 * @returns {string} The highlighted HTML.
-		 * @memberof Prism
-		 * @public
-		 * @example
-		 * Prism.highlight('var foo = true;', Prism.languages.javascript, 'javascript');
-		 */
-		highlight: function (text, grammar, language) {
-			var env = {
-				code: text,
-				grammar: grammar,
-				language: language
-			};
-			_.hooks.run('before-tokenize', env);
-			env.tokens = _.tokenize(env.code, env.grammar);
-			_.hooks.run('after-tokenize', env);
-			return Token.stringify(_.util.encode(env.tokens), env.language);
-		},
-
-		/**
-		 * This is the heart of Prism, and the most low-level function you can use. It accepts a string of text as input
-		 * and the language definitions to use, and returns an array with the tokenized code.
-		 *
-		 * When the language definition includes nested tokens, the function is called recursively on each of these tokens.
-		 *
-		 * This method could be useful in other contexts as well, as a very crude parser.
-		 *
-		 * @param {string} text A string with the code to be highlighted.
-		 * @param {Grammar} grammar An object containing the tokens to use.
-		 *
-		 * Usually a language definition like `Prism.languages.markup`.
-		 * @returns {TokenStream} An array of strings and tokens, a token stream.
-		 * @memberof Prism
-		 * @public
-		 * @example
-		 * let code = `var foo = 0;`;
-		 * let tokens = Prism.tokenize(code, Prism.languages.javascript);
-		 * tokens.forEach(token => {
-		 *     if (token instanceof Prism.Token && token.type === 'number') {
-		 *         console.log(`Found numeric literal: ${token.content}`);
-		 *     }
-		 * });
-		 */
-		tokenize: function (text, grammar) {
-			var rest = grammar.rest;
-			if (rest) {
-				for (var token in rest) {
-					grammar[token] = rest[token];
-				}
-
-				delete grammar.rest;
-			}
-
-			var tokenList = new LinkedList();
-			addAfter(tokenList, tokenList.head, text);
-
-			matchGrammar(text, tokenList, grammar, tokenList.head, 0);
-
-			return toArray(tokenList);
-		},
-
-		/**
-		 * @namespace
-		 * @memberof Prism
-		 * @public
-		 */
-		hooks: {
-			all: {},
-
-			/**
-			 * Adds the given callback to the list of callbacks for the given hook.
-			 *
-			 * The callback will be invoked when the hook it is registered for is run.
-			 * Hooks are usually directly run by a highlight function but you can also run hooks yourself.
-			 *
-			 * One callback function can be registered to multiple hooks and the same hook multiple times.
-			 *
-			 * @param {string} name The name of the hook.
-			 * @param {HookCallback} callback The callback function which is given environment variables.
-			 * @public
-			 */
-			add: function (name, callback) {
-				var hooks = _.hooks.all;
-
-				hooks[name] = hooks[name] || [];
-
-				hooks[name].push(callback);
-			},
-
-			/**
-			 * Runs a hook invoking all registered callbacks with the given environment variables.
-			 *
-			 * Callbacks will be invoked synchronously and in the order in which they were registered.
-			 *
-			 * @param {string} name The name of the hook.
-			 * @param {Object<string, any>} env The environment variables of the hook passed to all callbacks registered.
-			 * @public
-			 */
-			run: function (name, env) {
-				var callbacks = _.hooks.all[name];
-
-				if (!callbacks || !callbacks.length) {
-					return;
-				}
-
-				for (var i = 0, callback; (callback = callbacks[i++]);) {
-					callback(env);
-				}
-			}
-		},
-
-		Token: Token
-	};
-	_self.Prism = _;
-
-
-	// Typescript note:
-	// The following can be used to import the Token type in JSDoc:
-	//
-	//   @typedef {InstanceType<import("./prism-core")["Token"]>} Token
-
-	/**
-	 * Creates a new token.
-	 *
-	 * @param {string} type See {@link Token#type type}
-	 * @param {string | TokenStream} content See {@link Token#content content}
-	 * @param {string|string[]} [alias] The alias(es) of the token.
-	 * @param {string} [matchedStr=""] A copy of the full string this token was created from.
-	 * @class
-	 * @global
-	 * @public
-	 */
-	function Token(type, content, alias, matchedStr) {
-		/**
-		 * The type of the token.
-		 *
-		 * This is usually the key of a pattern in a {@link Grammar}.
-		 *
-		 * @type {string}
-		 * @see GrammarToken
-		 * @public
-		 */
-		this.type = type;
-		/**
-		 * The strings or tokens contained by this token.
-		 *
-		 * This will be a token stream if the pattern matched also defined an `inside` grammar.
-		 *
-		 * @type {string | TokenStream}
-		 * @public
-		 */
-		this.content = content;
-		/**
-		 * The alias(es) of the token.
-		 *
-		 * @type {string|string[]}
-		 * @see GrammarToken
-		 * @public
-		 */
-		this.alias = alias;
-		// Copy of the full string this token was created from
-		this.length = (matchedStr || '').length | 0;
-	}
-
-	/**
-	 * A token stream is an array of strings and {@link Token Token} objects.
-	 *
-	 * Token streams have to fulfill a few properties that are assumed by most functions (mostly internal ones) that process
-	 * them.
-	 *
-	 * 1. No adjacent strings.
-	 * 2. No empty strings.
-	 *
-	 *    The only exception here is the token stream that only contains the empty string and nothing else.
-	 *
-	 * @typedef {Array<string | Token>} TokenStream
-	 * @global
-	 * @public
-	 */
-
-	/**
-	 * Converts the given token or token stream to an HTML representation.
-	 *
-	 * The following hooks will be run:
-	 * 1. `wrap`: On each {@link Token}.
-	 *
-	 * @param {string | Token | TokenStream} o The token or token stream to be converted.
-	 * @param {string} language The name of current language.
-	 * @returns {string} The HTML representation of the token or token stream.
-	 * @memberof Token
-	 * @static
-	 */
-	Token.stringify = function stringify(o, language) {
-		if (typeof o == 'string') {
-			return o;
-		}
-		if (Array.isArray(o)) {
-			var s = '';
-			o.forEach(function (e) {
-				s += stringify(e, language);
-			});
-			return s;
-		}
-
-		var env = {
-			type: o.type,
-			content: stringify(o.content, language),
-			tag: 'span',
-			classes: ['token', o.type],
-			attributes: {},
-			language: language
-		};
-
-		var aliases = o.alias;
-		if (aliases) {
-			if (Array.isArray(aliases)) {
-				Array.prototype.push.apply(env.classes, aliases);
-			} else {
-				env.classes.push(aliases);
-			}
-		}
-
-		_.hooks.run('wrap', env);
-
-		var attributes = '';
-		for (var name in env.attributes) {
-			attributes += ' ' + name + '="' + (env.attributes[name] || '').replace(/"/g, '&quot;') + '"';
-		}
-
-		return '<' + env.tag + ' class="' + env.classes.join(' ') + '"' + attributes + '>' + env.content + '</' + env.tag + '>';
-	};
-
-	/**
-	 * @param {RegExp} pattern
-	 * @param {number} pos
-	 * @param {string} text
-	 * @param {boolean} lookbehind
-	 * @returns {RegExpExecArray | null}
-	 */
-	function matchPattern(pattern, pos, text, lookbehind) {
-		pattern.lastIndex = pos;
-		var match = pattern.exec(text);
-		if (match && lookbehind && match[1]) {
-			// change the match to remove the text matched by the Prism lookbehind group
-			var lookbehindLength = match[1].length;
-			match.index += lookbehindLength;
-			match[0] = match[0].slice(lookbehindLength);
-		}
-		return match;
-	}
-
-	/**
-	 * @param {string} text
-	 * @param {LinkedList<string | Token>} tokenList
-	 * @param {any} grammar
-	 * @param {LinkedListNode<string | Token>} startNode
-	 * @param {number} startPos
-	 * @param {RematchOptions} [rematch]
-	 * @returns {void}
-	 * @private
-	 *
-	 * @typedef RematchOptions
-	 * @property {string} cause
-	 * @property {number} reach
-	 */
-	function matchGrammar(text, tokenList, grammar, startNode, startPos, rematch) {
-		for (var token in grammar) {
-			if (!grammar.hasOwnProperty(token) || !grammar[token]) {
-				continue;
-			}
-
-			var patterns = grammar[token];
-			patterns = Array.isArray(patterns) ? patterns : [patterns];
-
-			for (var j = 0; j < patterns.length; ++j) {
-				if (rematch && rematch.cause == token + ',' + j) {
-					return;
-				}
-
-				var patternObj = patterns[j];
-				var inside = patternObj.inside;
-				var lookbehind = !!patternObj.lookbehind;
-				var greedy = !!patternObj.greedy;
-				var alias = patternObj.alias;
-
-				if (greedy && !patternObj.pattern.global) {
-					// Without the global flag, lastIndex won't work
-					var flags = patternObj.pattern.toString().match(/[imsuy]*$/)[0];
-					patternObj.pattern = RegExp(patternObj.pattern.source, flags + 'g');
-				}
-
-				/** @type {RegExp} */
-				var pattern = patternObj.pattern || patternObj;
-
-				for ( // iterate the token list and keep track of the current token/string position
-					var currentNode = startNode.next, pos = startPos;
-					currentNode !== tokenList.tail;
-					pos += currentNode.value.length, currentNode = currentNode.next
-				) {
-
-					if (rematch && pos >= rematch.reach) {
-						break;
-					}
-
-					var str = currentNode.value;
-
-					if (tokenList.length > text.length) {
-						// Something went terribly wrong, ABORT, ABORT!
-						return;
-					}
-
-					if (str instanceof Token) {
-						continue;
-					}
-
-					var removeCount = 1; // this is the to parameter of removeBetween
-					var match;
-
-					if (greedy) {
-						match = matchPattern(pattern, pos, text, lookbehind);
-						if (!match) {
-							break;
-						}
-
-						var from = match.index;
-						var to = match.index + match[0].length;
-						var p = pos;
-
-						// find the node that contains the match
-						p += currentNode.value.length;
-						while (from >= p) {
-							currentNode = currentNode.next;
-							p += currentNode.value.length;
-						}
-						// adjust pos (and p)
-						p -= currentNode.value.length;
-						pos = p;
-
-						// the current node is a Token, then the match starts inside another Token, which is invalid
-						if (currentNode.value instanceof Token) {
-							continue;
-						}
-
-						// find the last node which is affected by this match
-						for (
-							var k = currentNode;
-							k !== tokenList.tail && (p < to || typeof k.value === 'string');
-							k = k.next
-						) {
-							removeCount++;
-							p += k.value.length;
-						}
-						removeCount--;
-
-						// replace with the new match
-						str = text.slice(pos, p);
-						match.index -= pos;
-					} else {
-						match = matchPattern(pattern, 0, str, lookbehind);
-						if (!match) {
-							continue;
-						}
-					}
-
-					// eslint-disable-next-line no-redeclare
-					var from = match.index;
-					var matchStr = match[0];
-					var before = str.slice(0, from);
-					var after = str.slice(from + matchStr.length);
-
-					var reach = pos + str.length;
-					if (rematch && reach > rematch.reach) {
-						rematch.reach = reach;
-					}
-
-					var removeFrom = currentNode.prev;
-
-					if (before) {
-						removeFrom = addAfter(tokenList, removeFrom, before);
-						pos += before.length;
-					}
-
-					removeRange(tokenList, removeFrom, removeCount);
-
-					var wrapped = new Token(token, inside ? _.tokenize(matchStr, inside) : matchStr, alias, matchStr);
-					currentNode = addAfter(tokenList, removeFrom, wrapped);
-
-					if (after) {
-						addAfter(tokenList, currentNode, after);
-					}
-
-					if (removeCount > 1) {
-						// at least one Token object was removed, so we have to do some rematching
-						// this can only happen if the current pattern is greedy
-
-						/** @type {RematchOptions} */
-						var nestedRematch = {
-							cause: token + ',' + j,
-							reach: reach
-						};
-						matchGrammar(text, tokenList, grammar, currentNode.prev, pos, nestedRematch);
-
-						// the reach might have been extended because of the rematching
-						if (rematch && nestedRematch.reach > rematch.reach) {
-							rematch.reach = nestedRematch.reach;
-						}
-					}
-				}
-			}
-		}
-	}
-
-	/**
-	 * @typedef LinkedListNode
-	 * @property {T} value
-	 * @property {LinkedListNode<T> | null} prev The previous node.
-	 * @property {LinkedListNode<T> | null} next The next node.
-	 * @template T
-	 * @private
-	 */
-
-	/**
-	 * @template T
-	 * @private
-	 */
-	function LinkedList() {
-		/** @type {LinkedListNode<T>} */
-		var head = { value: null, prev: null, next: null };
-		/** @type {LinkedListNode<T>} */
-		var tail = { value: null, prev: head, next: null };
-		head.next = tail;
-
-		/** @type {LinkedListNode<T>} */
-		this.head = head;
-		/** @type {LinkedListNode<T>} */
-		this.tail = tail;
-		this.length = 0;
-	}
-
-	/**
-	 * Adds a new node with the given value to the list.
-	 *
-	 * @param {LinkedList<T>} list
-	 * @param {LinkedListNode<T>} node
-	 * @param {T} value
-	 * @returns {LinkedListNode<T>} The added node.
-	 * @template T
-	 */
-	function addAfter(list, node, value) {
-		// assumes that node != list.tail && values.length >= 0
-		var next = node.next;
-
-		var newNode = { value: value, prev: node, next: next };
-		node.next = newNode;
-		next.prev = newNode;
-		list.length++;
-
-		return newNode;
-	}
-	/**
-	 * Removes `count` nodes after the given node. The given node will not be removed.
-	 *
-	 * @param {LinkedList<T>} list
-	 * @param {LinkedListNode<T>} node
-	 * @param {number} count
-	 * @template T
-	 */
-	function removeRange(list, node, count) {
-		var next = node.next;
-		for (var i = 0; i < count && next !== list.tail; i++) {
-			next = next.next;
-		}
-		node.next = next;
-		next.prev = node;
-		list.length -= i;
-	}
-	/**
-	 * @param {LinkedList<T>} list
-	 * @returns {T[]}
-	 * @template T
-	 */
-	function toArray(list) {
-		var array = [];
-		var node = list.head.next;
-		while (node !== list.tail) {
-			array.push(node.value);
-			node = node.next;
-		}
-		return array;
-	}
-
-
-	if (!_self.document) {
-		if (!_self.addEventListener) {
-			// in Node.js
-			return _;
-		}
-
-		if (!_.disableWorkerMessageHandler) {
-			// In worker
-			_self.addEventListener('message', function (evt) {
-				var message = JSON.parse(evt.data);
-				var lang = message.language;
-				var code = message.code;
-				var immediateClose = message.immediateClose;
-
-				_self.postMessage(_.highlight(code, _.languages[lang], lang));
-				if (immediateClose) {
-					_self.close();
-				}
-			}, false);
-		}
-
-		return _;
-	}
-
-	// Get current script and highlight
-	var script = _.util.currentScript();
-
-	if (script) {
-		_.filename = script.src;
-
-		if (script.hasAttribute('data-manual')) {
-			_.manual = true;
-		}
-	}
-
-	function highlightAutomaticallyCallback() {
-		if (!_.manual) {
-			_.highlightAll();
-		}
-	}
-
-	if (!_.manual) {
-		// If the document state is "loading", then we'll use DOMContentLoaded.
-		// If the document state is "interactive" and the prism.js script is deferred, then we'll also use the
-		// DOMContentLoaded event because there might be some plugins or languages which have also been deferred and they
-		// might take longer one animation frame to execute which can create a race condition where only some plugins have
-		// been loaded when Prism.highlightAll() is executed, depending on how fast resources are loaded.
-		// See https://github.com/PrismJS/prism/issues/2102
-		var readyState = document.readyState;
-		if (readyState === 'loading' || readyState === 'interactive' && script && script.defer) {
-			document.addEventListener('DOMContentLoaded', highlightAutomaticallyCallback);
-		} else {
-			if (window.requestAnimationFrame) {
-				window.requestAnimationFrame(highlightAutomaticallyCallback);
-			} else {
-				window.setTimeout(highlightAutomaticallyCallback, 16);
-			}
-		}
-	}
-
-	return _;
+  // Private helper vars
+  var lang = /(?:^|\s)lang(?:uage)?-([\w-]+)(?=\s|$)/i;
+  var uniqueId = 0;
+
+  // The grammar object for plaintext
+  var plainTextGrammar = {};
+
+
+  var _ = {
+    /**
+     * By default, Prism will attempt to highlight all code elements (by calling {@link Prism.highlightAll}) on the
+     * current page after the page finished loading. This might be a problem if e.g. you wanted to asynchronously load
+     * additional languages or plugins yourself.
+     *
+     * By setting this value to `true`, Prism will not automatically highlight all code elements on the page.
+     *
+     * You obviously have to change this value before the automatic highlighting started. To do this, you can add an
+     * empty Prism object into the global scope before loading the Prism script like this:
+     *
+     * ```js
+     * window.Prism = window.Prism || {};
+     * Prism.manual = true;
+     * // add a new <script> to load Prism's script
+     * ```
+     *
+     * @default false
+     * @type {boolean}
+     * @memberof Prism
+     * @public
+     */
+    manual: _self.Prism && _self.Prism.manual,
+    /**
+     * By default, if Prism is in a web worker, it assumes that it is in a worker it created itself, so it uses
+     * `addEventListener` to communicate with its parent instance. However, if you're using Prism manually in your
+     * own worker, you don't want it to do this.
+     *
+     * By setting this value to `true`, Prism will not add its own listeners to the worker.
+     *
+     * You obviously have to change this value before Prism executes. To do this, you can add an
+     * empty Prism object into the global scope before loading the Prism script like this:
+     *
+     * ```js
+     * window.Prism = window.Prism || {};
+     * Prism.disableWorkerMessageHandler = true;
+     * // Load Prism's script
+     * ```
+     *
+     * @default false
+     * @type {boolean}
+     * @memberof Prism
+     * @public
+     */
+    disableWorkerMessageHandler: _self.Prism && _self.Prism.disableWorkerMessageHandler,
+
+    /**
+     * A namespace for utility methods.
+     *
+     * All function in this namespace that are not explicitly marked as _public_ are for __internal use only__ and may
+     * change or disappear at any time.
+     *
+     * @namespace
+     * @memberof Prism
+     */
+    util: {
+      encode: function encode(tokens) {
+        if (tokens instanceof Token) {
+          return new Token(tokens.type, encode(tokens.content), tokens.alias);
+        } else if (Array.isArray(tokens)) {
+          return tokens.map(encode);
+        } else {
+          return tokens.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/\u00a0/g, ' ');
+        }
+      },
+
+      /**
+       * Returns the name of the type of the given value.
+       *
+       * @param {any} o
+       * @returns {string}
+       * @example
+       * type(null)      === 'Null'
+       * type(undefined) === 'Undefined'
+       * type(123)       === 'Number'
+       * type('foo')     === 'String'
+       * type(true)      === 'Boolean'
+       * type([1, 2])    === 'Array'
+       * type({})        === 'Object'
+       * type(String)    === 'Function'
+       * type(/abc+/)    === 'RegExp'
+       */
+      type: function (o) {
+        return Object.prototype.toString.call(o).slice(8, -1);
+      },
+
+      /**
+       * Returns a unique number for the given object. Later calls will still return the same number.
+       *
+       * @param {Object} obj
+       * @returns {number}
+       */
+      objId: function (obj) {
+        if (!obj['__id']) {
+          Object.defineProperty(obj, '__id', { value: ++uniqueId });
+        }
+        return obj['__id'];
+      },
+
+      /**
+       * Creates a deep clone of the given object.
+       *
+       * The main intended use of this function is to clone language definitions.
+       *
+       * @param {T} o
+       * @param {Record<number, any>} [visited]
+       * @returns {T}
+       * @template T
+       */
+      clone: function deepClone(o, visited) {
+        visited = visited || {};
+
+        var clone; var id;
+        switch (_.util.type(o)) {
+          case 'Object':
+            id = _.util.objId(o);
+            if (visited[id]) {
+              return visited[id];
+            }
+            clone = /** @type {Record<string, any>} */ ({});
+            visited[id] = clone;
+
+            for (var key in o) {
+              if (o.hasOwnProperty(key)) {
+                clone[key] = deepClone(o[key], visited);
+              }
+            }
+
+            return /** @type {any} */ (clone);
+
+          case 'Array':
+            id = _.util.objId(o);
+            if (visited[id]) {
+              return visited[id];
+            }
+            clone = [];
+            visited[id] = clone;
+
+            (/** @type {Array} */(/** @type {any} */(o))).forEach(function (v, i) {
+              clone[i] = deepClone(v, visited);
+            });
+
+            return /** @type {any} */ (clone);
+
+          default:
+            return o;
+        }
+      },
+
+      /**
+       * Returns the Prism language of the given element set by a `language-xxxx` or `lang-xxxx` class.
+       *
+       * If no language is set for the element or the element is `null` or `undefined`, `none` will be returned.
+       *
+       * @param {Element} element
+       * @returns {string}
+       */
+      getLanguage: function (element) {
+        while (element) {
+          var m = lang.exec(element.className);
+          if (m) {
+            return m[1].toLowerCase();
+          }
+          element = element.parentElement;
+        }
+        return 'none';
+      },
+
+      /**
+       * Sets the Prism `language-xxxx` class of the given element.
+       *
+       * @param {Element} element
+       * @param {string} language
+       * @returns {void}
+       */
+      setLanguage: function (element, language) {
+        // remove all `language-xxxx` classes
+        // (this might leave behind a leading space)
+        element.className = element.className.replace(RegExp(lang, 'gi'), '');
+
+        // add the new `language-xxxx` class
+        // (using `classList` will automatically clean up spaces for us)
+        element.classList.add('language-' + language);
+      },
+
+      /**
+       * Returns the script element that is currently executing.
+       *
+       * This does __not__ work for line script element.
+       *
+       * @returns {HTMLScriptElement | null}
+       */
+      currentScript: function () {
+        if (typeof document === 'undefined') {
+          return null;
+        }
+        if ('currentScript' in document && 1 < 2 /* hack to trip TS' flow analysis */) {
+          return /** @type {any} */ (document.currentScript);
+        }
+
+        // IE11 workaround
+        // we'll get the src of the current script by parsing IE11's error stack trace
+        // this will not work for inline scripts
+
+        try {
+          throw new Error();
+        } catch (err) {
+          // Get file src url from stack. Specifically works with the format of stack traces in IE.
+          // A stack will look like this:
+          //
+          // Error
+          //    at _.util.currentScript (http://localhost/components/prism-core.js:119:5)
+          //    at Global code (http://localhost/components/prism-core.js:606:1)
+
+          var src = (/at [^(\r\n]*\((.*):[^:]+:[^:]+\)$/i.exec(err.stack) || [])[1];
+          if (src) {
+            var scripts = document.getElementsByTagName('script');
+            for (var i in scripts) {
+              if (scripts[i].src == src) {
+                return scripts[i];
+              }
+            }
+          }
+          return null;
+        }
+      },
+
+      /**
+       * Returns whether a given class is active for `element`.
+       *
+       * The class can be activated if `element` or one of its ancestors has the given class and it can be deactivated
+       * if `element` or one of its ancestors has the negated version of the given class. The _negated version_ of the
+       * given class is just the given class with a `no-` prefix.
+       *
+       * Whether the class is active is determined by the closest ancestor of `element` (where `element` itself is
+       * closest ancestor) that has the given class or the negated version of it. If neither `element` nor any of its
+       * ancestors have the given class or the negated version of it, then the default activation will be returned.
+       *
+       * In the paradoxical situation where the closest ancestor contains __both__ the given class and the negated
+       * version of it, the class is considered active.
+       *
+       * @param {Element} element
+       * @param {string} className
+       * @param {boolean} [defaultActivation=false]
+       * @returns {boolean}
+       */
+      isActive: function (element, className, defaultActivation) {
+        var no = 'no-' + className;
+
+        while (element) {
+          var classList = element.classList;
+          if (classList.contains(className)) {
+            return true;
+          }
+          if (classList.contains(no)) {
+            return false;
+          }
+          element = element.parentElement;
+        }
+        return !!defaultActivation;
+      }
+    },
+
+    /**
+     * This namespace contains all currently loaded languages and the some helper functions to create and modify languages.
+     *
+     * @namespace
+     * @memberof Prism
+     * @public
+     */
+    languages: {
+      /**
+       * The grammar for plain, unformatted text.
+       */
+      plain: plainTextGrammar,
+      plaintext: plainTextGrammar,
+      text: plainTextGrammar,
+      txt: plainTextGrammar,
+
+      /**
+       * Creates a deep copy of the language with the given id and appends the given tokens.
+       *
+       * If a token in `redef` also appears in the copied language, then the existing token in the copied language
+       * will be overwritten at its original position.
+       *
+       * ## Best practices
+       *
+       * Since the position of overwriting tokens (token in `redef` that overwrite tokens in the copied language)
+       * doesn't matter, they can technically be in any order. However, this can be confusing to others that trying to
+       * understand the language definition because, normally, the order of tokens matters in Prism grammars.
+       *
+       * Therefore, it is encouraged to order overwriting tokens according to the positions of the overwritten tokens.
+       * Furthermore, all non-overwriting tokens should be placed after the overwriting ones.
+       *
+       * @param {string} id The id of the language to extend. This has to be a key in `Prism.languages`.
+       * @param {Grammar} redef The new tokens to append.
+       * @returns {Grammar} The new language created.
+       * @public
+       * @example
+       * Prism.languages['css-with-colors'] = Prism.languages.extend('css', {
+       *     // Prism.languages.css already has a 'comment' token, so this token will overwrite CSS' 'comment' token
+       *     // at its original position
+       *     'comment': { ... },
+       *     // CSS doesn't have a 'color' token, so this token will be appended
+       *     'color': /\b(?:red|green|blue)\b/
+       * });
+       */
+      extend: function (id, redef) {
+        var lang = _.util.clone(_.languages[id]);
+
+        for (var key in redef) {
+          lang[key] = redef[key];
+        }
+
+        return lang;
+      },
+
+      /**
+       * Inserts tokens _before_ another token in a language definition or any other grammar.
+       *
+       * ## Usage
+       *
+       * This helper method makes it easy to modify existing languages. For example, the CSS language definition
+       * not only defines CSS highlighting for CSS documents, but also needs to define highlighting for CSS embedded
+       * in HTML through `<style>` elements. To do this, it needs to modify `Prism.languages.markup` and add the
+       * appropriate tokens. However, `Prism.languages.markup` is a regular JavaScript object literal, so if you do
+       * this:
+       *
+       * ```js
+       * Prism.languages.markup.style = {
+       *     // token
+       * };
+       * ```
+       *
+       * then the `style` token will be added (and processed) at the end. `insertBefore` allows you to insert tokens
+       * before existing tokens. For the CSS example above, you would use it like this:
+       *
+       * ```js
+       * Prism.languages.insertBefore('markup', 'cdata', {
+       *     'style': {
+       *         // token
+       *     }
+       * });
+       * ```
+       *
+       * ## Special cases
+       *
+       * If the grammars of `inside` and `insert` have tokens with the same name, the tokens in `inside`'s grammar
+       * will be ignored.
+       *
+       * This behavior can be used to insert tokens after `before`:
+       *
+       * ```js
+       * Prism.languages.insertBefore('markup', 'comment', {
+       *     'comment': Prism.languages.markup.comment,
+       *     // tokens after 'comment'
+       * });
+       * ```
+       *
+       * ## Limitations
+       *
+       * The main problem `insertBefore` has to solve is iteration order. Since ES2015, the iteration order for object
+       * properties is guaranteed to be the insertion order (except for integer keys) but some browsers behave
+       * differently when keys are deleted and re-inserted. So `insertBefore` can't be implemented by temporarily
+       * deleting properties which is necessary to insert at arbitrary positions.
+       *
+       * To solve this problem, `insertBefore` doesn't actually insert the given tokens into the target object.
+       * Instead, it will create a new object and replace all references to the target object with the new one. This
+       * can be done without temporarily deleting properties, so the iteration order is well-defined.
+       *
+       * However, only references that can be reached from `Prism.languages` or `insert` will be replaced. I.e. if
+       * you hold the target object in a variable, then the value of the variable will not change.
+       *
+       * ```js
+       * var oldMarkup = Prism.languages.markup;
+       * var newMarkup = Prism.languages.insertBefore('markup', 'comment', { ... });
+       *
+       * assert(oldMarkup !== Prism.languages.markup);
+       * assert(newMarkup === Prism.languages.markup);
+       * ```
+       *
+       * @param {string} inside The property of `root` (e.g. a language id in `Prism.languages`) that contains the
+       * object to be modified.
+       * @param {string} before The key to insert before.
+       * @param {Grammar} insert An object containing the key-value pairs to be inserted.
+       * @param {Object<string, any>} [root] The object containing `inside`, i.e. the object that contains the
+       * object to be modified.
+       *
+       * Defaults to `Prism.languages`.
+       * @returns {Grammar} The new grammar object.
+       * @public
+       */
+      insertBefore: function (inside, before, insert, root) {
+        root = root || /** @type {any} */ (_.languages);
+        var grammar = root[inside];
+        /** @type {Grammar} */
+        var ret = {};
+
+        for (var token in grammar) {
+          if (grammar.hasOwnProperty(token)) {
+
+            if (token == before) {
+              for (var newToken in insert) {
+                if (insert.hasOwnProperty(newToken)) {
+                  ret[newToken] = insert[newToken];
+                }
+              }
+            }
+
+            // Do not insert token which also occur in insert. See #1525
+            if (!insert.hasOwnProperty(token)) {
+              ret[token] = grammar[token];
+            }
+          }
+        }
+
+        var old = root[inside];
+        root[inside] = ret;
+
+        // Update references in other language definitions
+        _.languages.DFS(_.languages, function (key, value) {
+          if (value === old && key != inside) {
+            this[key] = ret;
+          }
+        });
+
+        return ret;
+      },
+
+      // Traverse a language definition with Depth First Search
+      DFS: function DFS(o, callback, type, visited) {
+        visited = visited || {};
+
+        var objId = _.util.objId;
+
+        for (var i in o) {
+          if (o.hasOwnProperty(i)) {
+            callback.call(o, i, o[i], type || i);
+
+            var property = o[i];
+            var propertyType = _.util.type(property);
+
+            if (propertyType === 'Object' && !visited[objId(property)]) {
+              visited[objId(property)] = true;
+              DFS(property, callback, null, visited);
+            } else if (propertyType === 'Array' && !visited[objId(property)]) {
+              visited[objId(property)] = true;
+              DFS(property, callback, i, visited);
+            }
+          }
+        }
+      }
+    },
+
+    plugins: {},
+
+    /**
+     * This is the most high-level function in Prism’s API.
+     * It fetches all the elements that have a `.language-xxxx` class and then calls {@link Prism.highlightElement} on
+     * each one of them.
+     *
+     * This is equivalent to `Prism.highlightAllUnder(document, async, callback)`.
+     *
+     * @param {boolean} [async=false] Same as in {@link Prism.highlightAllUnder}.
+     * @param {HighlightCallback} [callback] Same as in {@link Prism.highlightAllUnder}.
+     * @memberof Prism
+     * @public
+     */
+    highlightAll: function (async, callback) {
+      _.highlightAllUnder(document, async, callback);
+    },
+
+    /**
+     * Fetches all the descendants of `container` that have a `.language-xxxx` class and then calls
+     * {@link Prism.highlightElement} on each one of them.
+     *
+     * The following hooks will be run:
+     * 1. `before-highlightall`
+     * 2. `before-all-elements-highlight`
+     * 3. All hooks of {@link Prism.highlightElement} for each element.
+     *
+     * @param {ParentNode} container The root element, whose descendants that have a `.language-xxxx` class will be highlighted.
+     * @param {boolean} [async=false] Whether each element is to be highlighted asynchronously using Web Workers.
+     * @param {HighlightCallback} [callback] An optional callback to be invoked on each element after its highlighting is done.
+     * @memberof Prism
+     * @public
+     */
+    highlightAllUnder: function (container, async, callback) {
+      var env = {
+        callback: callback,
+        container: container,
+        selector: 'code[class*="language-"], [class*="language-"] code, code[class*="lang-"], [class*="lang-"] code'
+      };
+
+      _.hooks.run('before-highlightall', env);
+
+      env.elements = Array.prototype.slice.apply(env.container.querySelectorAll(env.selector));
+
+      _.hooks.run('before-all-elements-highlight', env);
+
+      for (var i = 0, element; (element = env.elements[i++]);) {
+        _.highlightElement(element, async === true, env.callback);
+      }
+    },
+
+    /**
+     * Highlights the code inside a single element.
+     *
+     * The following hooks will be run:
+     * 1. `before-sanity-check`
+     * 2. `before-highlight`
+     * 3. All hooks of {@link Prism.highlight}. These hooks will be run by an asynchronous worker if `async` is `true`.
+     * 4. `before-insert`
+     * 5. `after-highlight`
+     * 6. `complete`
+     *
+     * Some the above hooks will be skipped if the element doesn't contain any text or there is no grammar loaded for
+     * the element's language.
+     *
+     * @param {Element} element The element containing the code.
+     * It must have a class of `language-xxxx` to be processed, where `xxxx` is a valid language identifier.
+     * @param {boolean} [async=false] Whether the element is to be highlighted asynchronously using Web Workers
+     * to improve performance and avoid blocking the UI when highlighting very large chunks of code. This option is
+     * [disabled by default](https://prismjs.com/faq.html#why-is-asynchronous-highlighting-disabled-by-default).
+     *
+     * Note: All language definitions required to highlight the code must be included in the main `prism.js` file for
+     * asynchronous highlighting to work. You can build your own bundle on the
+     * [Download page](https://prismjs.com/download.html).
+     * @param {HighlightCallback} [callback] An optional callback to be invoked after the highlighting is done.
+     * Mostly useful when `async` is `true`, since in that case, the highlighting is done asynchronously.
+     * @memberof Prism
+     * @public
+     */
+    highlightElement: function (element, async, callback) {
+      // Find language
+      var language = _.util.getLanguage(element);
+      var grammar = _.languages[language];
+
+      // Set language on the element, if not present
+      _.util.setLanguage(element, language);
+
+      // Set language on the parent, for styling
+      var parent = element.parentElement;
+      if (parent && parent.nodeName.toLowerCase() === 'pre') {
+        _.util.setLanguage(parent, language);
+      }
+
+      var code = element.textContent;
+
+      var env = {
+        element: element,
+        language: language,
+        grammar: grammar,
+        code: code
+      };
+
+      function insertHighlightedCode(highlightedCode) {
+        env.highlightedCode = highlightedCode;
+
+        _.hooks.run('before-insert', env);
+
+        env.element.innerHTML = env.highlightedCode;
+
+        _.hooks.run('after-highlight', env);
+        _.hooks.run('complete', env);
+        callback && callback.call(env.element);
+      }
+
+      _.hooks.run('before-sanity-check', env);
+
+      // plugins may change/add the parent/element
+      parent = env.element.parentElement;
+      if (parent && parent.nodeName.toLowerCase() === 'pre' && !parent.hasAttribute('tabindex')) {
+        parent.setAttribute('tabindex', '0');
+      }
+
+      if (!env.code) {
+        _.hooks.run('complete', env);
+        callback && callback.call(env.element);
+        return;
+      }
+
+      _.hooks.run('before-highlight', env);
+
+      if (!env.grammar) {
+        insertHighlightedCode(_.util.encode(env.code));
+        return;
+      }
+
+      if (async && _self.Worker) {
+        var worker = new Worker(_.filename);
+
+        worker.onmessage = function (evt) {
+          insertHighlightedCode(evt.data);
+        };
+
+        worker.postMessage(JSON.stringify({
+          language: env.language,
+          code: env.code,
+          immediateClose: true
+        }));
+      } else {
+        insertHighlightedCode(_.highlight(env.code, env.grammar, env.language));
+      }
+    },
+
+    /**
+     * Low-level function, only use if you know what you’re doing. It accepts a string of text as input
+     * and the language definitions to use, and returns a string with the HTML produced.
+     *
+     * The following hooks will be run:
+     * 1. `before-tokenize`
+     * 2. `after-tokenize`
+     * 3. `wrap`: On each {@link Token}.
+     *
+     * @param {string} text A string with the code to be highlighted.
+     * @param {Grammar} grammar An object containing the tokens to use.
+     *
+     * Usually a language definition like `Prism.languages.markup`.
+     * @param {string} language The name of the language definition passed to `grammar`.
+     * @returns {string} The highlighted HTML.
+     * @memberof Prism
+     * @public
+     * @example
+     * Prism.highlight('var foo = true;', Prism.languages.javascript, 'javascript');
+     */
+    highlight: function (text, grammar, language) {
+      var env = {
+        code: text,
+        grammar: grammar,
+        language: language
+      };
+      _.hooks.run('before-tokenize', env);
+      env.tokens = _.tokenize(env.code, env.grammar);
+      _.hooks.run('after-tokenize', env);
+      return Token.stringify(_.util.encode(env.tokens), env.language);
+    },
+
+    /**
+     * This is the heart of Prism, and the most low-level function you can use. It accepts a string of text as input
+     * and the language definitions to use, and returns an array with the tokenized code.
+     *
+     * When the language definition includes nested tokens, the function is called recursively on each of these tokens.
+     *
+     * This method could be useful in other contexts as well, as a very crude parser.
+     *
+     * @param {string} text A string with the code to be highlighted.
+     * @param {Grammar} grammar An object containing the tokens to use.
+     *
+     * Usually a language definition like `Prism.languages.markup`.
+     * @returns {TokenStream} An array of strings and tokens, a token stream.
+     * @memberof Prism
+     * @public
+     * @example
+     * let code = `var foo = 0;`;
+     * let tokens = Prism.tokenize(code, Prism.languages.javascript);
+     * tokens.forEach(token => {
+     *     if (token instanceof Prism.Token && token.type === 'number') {
+     *         console.log(`Found numeric literal: ${token.content}`);
+     *     }
+     * });
+     */
+    tokenize: function (text, grammar) {
+      var rest = grammar.rest;
+      if (rest) {
+        for (var token in rest) {
+          grammar[token] = rest[token];
+        }
+
+        delete grammar.rest;
+      }
+
+      var tokenList = new LinkedList();
+      addAfter(tokenList, tokenList.head, text);
+
+      matchGrammar(text, tokenList, grammar, tokenList.head, 0);
+
+      return toArray(tokenList);
+    },
+
+    /**
+     * @namespace
+     * @memberof Prism
+     * @public
+     */
+    hooks: {
+      all: {},
+
+      /**
+       * Adds the given callback to the list of callbacks for the given hook.
+       *
+       * The callback will be invoked when the hook it is registered for is run.
+       * Hooks are usually directly run by a highlight function but you can also run hooks yourself.
+       *
+       * One callback function can be registered to multiple hooks and the same hook multiple times.
+       *
+       * @param {string} name The name of the hook.
+       * @param {HookCallback} callback The callback function which is given environment variables.
+       * @public
+       */
+      add: function (name, callback) {
+        var hooks = _.hooks.all;
+
+        hooks[name] = hooks[name] || [];
+
+        hooks[name].push(callback);
+      },
+
+      /**
+       * Runs a hook invoking all registered callbacks with the given environment variables.
+       *
+       * Callbacks will be invoked synchronously and in the order in which they were registered.
+       *
+       * @param {string} name The name of the hook.
+       * @param {Object<string, any>} env The environment variables of the hook passed to all callbacks registered.
+       * @public
+       */
+      run: function (name, env) {
+        var callbacks = _.hooks.all[name];
+
+        if (!callbacks || !callbacks.length) {
+          return;
+        }
+
+        for (var i = 0, callback; (callback = callbacks[i++]);) {
+          callback(env);
+        }
+      }
+    },
+
+    Token: Token
+  };
+  _self.Prism = _;
+
+
+  // Typescript note:
+  // The following can be used to import the Token type in JSDoc:
+  //
+  //   @typedef {InstanceType<import("./prism-core")["Token"]>} Token
+
+  /**
+   * Creates a new token.
+   *
+   * @param {string} type See {@link Token#type type}
+   * @param {string | TokenStream} content See {@link Token#content content}
+   * @param {string|string[]} [alias] The alias(es) of the token.
+   * @param {string} [matchedStr=""] A copy of the full string this token was created from.
+   * @class
+   * @global
+   * @public
+   */
+  function Token(type, content, alias, matchedStr) {
+    /**
+     * The type of the token.
+     *
+     * This is usually the key of a pattern in a {@link Grammar}.
+     *
+     * @type {string}
+     * @see GrammarToken
+     * @public
+     */
+    this.type = type;
+    /**
+     * The strings or tokens contained by this token.
+     *
+     * This will be a token stream if the pattern matched also defined an `inside` grammar.
+     *
+     * @type {string | TokenStream}
+     * @public
+     */
+    this.content = content;
+    /**
+     * The alias(es) of the token.
+     *
+     * @type {string|string[]}
+     * @see GrammarToken
+     * @public
+     */
+    this.alias = alias;
+    // Copy of the full string this token was created from
+    this.length = (matchedStr || '').length | 0;
+  }
+
+  /**
+   * A token stream is an array of strings and {@link Token Token} objects.
+   *
+   * Token streams have to fulfill a few properties that are assumed by most functions (mostly internal ones) that process
+   * them.
+   *
+   * 1. No adjacent strings.
+   * 2. No empty strings.
+   *
+   *    The only exception here is the token stream that only contains the empty string and nothing else.
+   *
+   * @typedef {Array<string | Token>} TokenStream
+   * @global
+   * @public
+   */
+
+  /**
+   * Converts the given token or token stream to an HTML representation.
+   *
+   * The following hooks will be run:
+   * 1. `wrap`: On each {@link Token}.
+   *
+   * @param {string | Token | TokenStream} o The token or token stream to be converted.
+   * @param {string} language The name of current language.
+   * @returns {string} The HTML representation of the token or token stream.
+   * @memberof Token
+   * @static
+   */
+  Token.stringify = function stringify(o, language) {
+    if (typeof o == 'string') {
+      return o;
+    }
+    if (Array.isArray(o)) {
+      var s = '';
+      o.forEach(function (e) {
+        s += stringify(e, language);
+      });
+      return s;
+    }
+
+    var env = {
+      type: o.type,
+      content: stringify(o.content, language),
+      tag: 'span',
+      classes: ['token', o.type],
+      attributes: {},
+      language: language
+    };
+
+    var aliases = o.alias;
+    if (aliases) {
+      if (Array.isArray(aliases)) {
+        Array.prototype.push.apply(env.classes, aliases);
+      } else {
+        env.classes.push(aliases);
+      }
+    }
+
+    _.hooks.run('wrap', env);
+
+    var attributes = '';
+    for (var name in env.attributes) {
+      attributes += ' ' + name + '="' + (env.attributes[name] || '').replace(/"/g, '&quot;') + '"';
+    }
+
+    return '<' + env.tag + ' class="' + env.classes.join(' ') + '"' + attributes + '>' + env.content + '</' + env.tag + '>';
+  };
+
+  /**
+   * @param {RegExp} pattern
+   * @param {number} pos
+   * @param {string} text
+   * @param {boolean} lookbehind
+   * @returns {RegExpExecArray | null}
+   */
+  function matchPattern(pattern, pos, text, lookbehind) {
+    pattern.lastIndex = pos;
+    var match = pattern.exec(text);
+    if (match && lookbehind && match[1]) {
+      // change the match to remove the text matched by the Prism lookbehind group
+      var lookbehindLength = match[1].length;
+      match.index += lookbehindLength;
+      match[0] = match[0].slice(lookbehindLength);
+    }
+    return match;
+  }
+
+  /**
+   * @param {string} text
+   * @param {LinkedList<string | Token>} tokenList
+   * @param {any} grammar
+   * @param {LinkedListNode<string | Token>} startNode
+   * @param {number} startPos
+   * @param {RematchOptions} [rematch]
+   * @returns {void}
+   * @private
+   *
+   * @typedef RematchOptions
+   * @property {string} cause
+   * @property {number} reach
+   */
+  function matchGrammar(text, tokenList, grammar, startNode, startPos, rematch) {
+    for (var token in grammar) {
+      if (!grammar.hasOwnProperty(token) || !grammar[token]) {
+        continue;
+      }
+
+      var patterns = grammar[token];
+      patterns = Array.isArray(patterns) ? patterns : [patterns];
+
+      for (var j = 0; j < patterns.length; ++j) {
+        if (rematch && rematch.cause == token + ',' + j) {
+          return;
+        }
+
+        var patternObj = patterns[j];
+        var inside = patternObj.inside;
+        var lookbehind = !!patternObj.lookbehind;
+        var greedy = !!patternObj.greedy;
+        var alias = patternObj.alias;
+
+        if (greedy && !patternObj.pattern.global) {
+          // Without the global flag, lastIndex won't work
+          var flags = patternObj.pattern.toString().match(/[imsuy]*$/)[0];
+          patternObj.pattern = RegExp(patternObj.pattern.source, flags + 'g');
+        }
+
+        /** @type {RegExp} */
+        var pattern = patternObj.pattern || patternObj;
+
+        for ( // iterate the token list and keep track of the current token/string position
+          var currentNode = startNode.next, pos = startPos;
+          currentNode !== tokenList.tail;
+          pos += currentNode.value.length, currentNode = currentNode.next
+        ) {
+
+          if (rematch && pos >= rematch.reach) {
+            break;
+          }
+
+          var str = currentNode.value;
+
+          if (tokenList.length > text.length) {
+            // Something went terribly wrong, ABORT, ABORT!
+            return;
+          }
+
+          if (str instanceof Token) {
+            continue;
+          }
+
+          var removeCount = 1; // this is the to parameter of removeBetween
+          var match;
+
+          if (greedy) {
+            match = matchPattern(pattern, pos, text, lookbehind);
+            if (!match || match.index >= text.length) {
+              break;
+            }
+
+            var from = match.index;
+            var to = match.index + match[0].length;
+            var p = pos;
+
+            // find the node that contains the match
+            p += currentNode.value.length;
+            while (from >= p) {
+              currentNode = currentNode.next;
+              p += currentNode.value.length;
+            }
+            // adjust pos (and p)
+            p -= currentNode.value.length;
+            pos = p;
+
+            // the current node is a Token, then the match starts inside another Token, which is invalid
+            if (currentNode.value instanceof Token) {
+              continue;
+            }
+
+            // find the last node which is affected by this match
+            for (
+              var k = currentNode;
+              k !== tokenList.tail && (p < to || typeof k.value === 'string');
+              k = k.next
+            ) {
+              removeCount++;
+              p += k.value.length;
+            }
+            removeCount--;
+
+            // replace with the new match
+            str = text.slice(pos, p);
+            match.index -= pos;
+          } else {
+            match = matchPattern(pattern, 0, str, lookbehind);
+            if (!match) {
+              continue;
+            }
+          }
+
+          // eslint-disable-next-line no-redeclare
+          var from = match.index;
+          var matchStr = match[0];
+          var before = str.slice(0, from);
+          var after = str.slice(from + matchStr.length);
+
+          var reach = pos + str.length;
+          if (rematch && reach > rematch.reach) {
+            rematch.reach = reach;
+          }
+
+          var removeFrom = currentNode.prev;
+
+          if (before) {
+            removeFrom = addAfter(tokenList, removeFrom, before);
+            pos += before.length;
+          }
+
+          removeRange(tokenList, removeFrom, removeCount);
+
+          var wrapped = new Token(token, inside ? _.tokenize(matchStr, inside) : matchStr, alias, matchStr);
+          currentNode = addAfter(tokenList, removeFrom, wrapped);
+
+          if (after) {
+            addAfter(tokenList, currentNode, after);
+          }
+
+          if (removeCount > 1) {
+            // at least one Token object was removed, so we have to do some rematching
+            // this can only happen if the current pattern is greedy
+
+            /** @type {RematchOptions} */
+            var nestedRematch = {
+              cause: token + ',' + j,
+              reach: reach
+            };
+            matchGrammar(text, tokenList, grammar, currentNode.prev, pos, nestedRematch);
+
+            // the reach might have been extended because of the rematching
+            if (rematch && nestedRematch.reach > rematch.reach) {
+              rematch.reach = nestedRematch.reach;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * @typedef LinkedListNode
+   * @property {T} value
+   * @property {LinkedListNode<T> | null} prev The previous node.
+   * @property {LinkedListNode<T> | null} next The next node.
+   * @template T
+   * @private
+   */
+
+  /**
+   * @template T
+   * @private
+   */
+  function LinkedList() {
+    /** @type {LinkedListNode<T>} */
+    var head = { value: null, prev: null, next: null };
+    /** @type {LinkedListNode<T>} */
+    var tail = { value: null, prev: head, next: null };
+    head.next = tail;
+
+    /** @type {LinkedListNode<T>} */
+    this.head = head;
+    /** @type {LinkedListNode<T>} */
+    this.tail = tail;
+    this.length = 0;
+  }
+
+  /**
+   * Adds a new node with the given value to the list.
+   *
+   * @param {LinkedList<T>} list
+   * @param {LinkedListNode<T>} node
+   * @param {T} value
+   * @returns {LinkedListNode<T>} The added node.
+   * @template T
+   */
+  function addAfter(list, node, value) {
+    // assumes that node != list.tail && values.length >= 0
+    var next = node.next;
+
+    var newNode = { value: value, prev: node, next: next };
+    node.next = newNode;
+    next.prev = newNode;
+    list.length++;
+
+    return newNode;
+  }
+  /**
+   * Removes `count` nodes after the given node. The given node will not be removed.
+   *
+   * @param {LinkedList<T>} list
+   * @param {LinkedListNode<T>} node
+   * @param {number} count
+   * @template T
+   */
+  function removeRange(list, node, count) {
+    var next = node.next;
+    for (var i = 0; i < count && next !== list.tail; i++) {
+      next = next.next;
+    }
+    node.next = next;
+    next.prev = node;
+    list.length -= i;
+  }
+  /**
+   * @param {LinkedList<T>} list
+   * @returns {T[]}
+   * @template T
+   */
+  function toArray(list) {
+    var array = [];
+    var node = list.head.next;
+    while (node !== list.tail) {
+      array.push(node.value);
+      node = node.next;
+    }
+    return array;
+  }
+
+
+  if (!_self.document) {
+    if (!_self.addEventListener) {
+      // in Node.js
+      return _;
+    }
+
+    if (!_.disableWorkerMessageHandler) {
+      // In worker
+      _self.addEventListener('message', function (evt) {
+        var message = JSON.parse(evt.data);
+        var lang = message.language;
+        var code = message.code;
+        var immediateClose = message.immediateClose;
+
+        _self.postMessage(_.highlight(code, _.languages[lang], lang));
+        if (immediateClose) {
+          _self.close();
+        }
+      }, false);
+    }
+
+    return _;
+  }
+
+  // Get current script and highlight
+  var script = _.util.currentScript();
+
+  if (script) {
+    _.filename = script.src;
+
+    if (script.hasAttribute('data-manual')) {
+      _.manual = true;
+    }
+  }
+
+  function highlightAutomaticallyCallback() {
+    if (!_.manual) {
+      _.highlightAll();
+    }
+  }
+
+  if (!_.manual) {
+    // If the document state is "loading", then we'll use DOMContentLoaded.
+    // If the document state is "interactive" and the prism.js script is deferred, then we'll also use the
+    // DOMContentLoaded event because there might be some plugins or languages which have also been deferred and they
+    // might take longer one animation frame to execute which can create a race condition where only some plugins have
+    // been loaded when Prism.highlightAll() is executed, depending on how fast resources are loaded.
+    // See https://github.com/PrismJS/prism/issues/2102
+    var readyState = document.readyState;
+    if (readyState === 'loading' || readyState === 'interactive' && script && script.defer) {
+      document.addEventListener('DOMContentLoaded', highlightAutomaticallyCallback);
+    } else {
+      if (window.requestAnimationFrame) {
+        window.requestAnimationFrame(highlightAutomaticallyCallback);
+      } else {
+        window.setTimeout(highlightAutomaticallyCallback, 16);
+      }
+    }
+  }
+
+  return _;
 
 }(_self));
 
 if (typeof module !== 'undefined' && module.exports) {
-	module.exports = Prism;
+  module.exports = Prism;
 }
 
 // hack for components to work correctly in node.js
 if (typeof global !== 'undefined') {
-	global.Prism = Prism;
+  global.Prism = Prism;
 }
 
 // some additional documentation/types
@@ -1223,169 +1262,178 @@ if (typeof global !== 'undefined') {
  */
 ;
 Prism.languages.markup = {
-	'comment': /<!--[\s\S]*?-->/,
-	'prolog': /<\?[\s\S]+?\?>/,
-	'doctype': {
-		// https://www.w3.org/TR/xml/#NT-doctypedecl
-		pattern: /<!DOCTYPE(?:[^>"'[\]]|"[^"]*"|'[^']*')+(?:\[(?:[^<"'\]]|"[^"]*"|'[^']*'|<(?!!--)|<!--(?:[^-]|-(?!->))*-->)*\]\s*)?>/i,
-		greedy: true,
-		inside: {
-			'internal-subset': {
-				pattern: /(^[^\[]*\[)[\s\S]+(?=\]>$)/,
-				lookbehind: true,
-				greedy: true,
-				inside: null // see below
-			},
-			'string': {
-				pattern: /"[^"]*"|'[^']*'/,
-				greedy: true
-			},
-			'punctuation': /^<!|>$|[[\]]/,
-			'doctype-tag': /^DOCTYPE/,
-			'name': /[^\s<>'"]+/
-		}
-	},
-	'cdata': /<!\[CDATA\[[\s\S]*?\]\]>/i,
-	'tag': {
-		pattern: /<\/?(?!\d)[^\s>\/=$<%]+(?:\s(?:\s*[^\s>\/=]+(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s'">=]+(?=[\s>]))|(?=[\s/>])))+)?\s*\/?>/,
-		greedy: true,
-		inside: {
-			'tag': {
-				pattern: /^<\/?[^\s>\/]+/,
-				inside: {
-					'punctuation': /^<\/?/,
-					'namespace': /^[^\s>\/:]+:/
-				}
-			},
-			'special-attr': [],
-			'attr-value': {
-				pattern: /=\s*(?:"[^"]*"|'[^']*'|[^\s'">=]+)/,
-				inside: {
-					'punctuation': [
-						{
-							pattern: /^=/,
-							alias: 'attr-equals'
-						},
-						/"|'/
-					]
-				}
-			},
-			'punctuation': /\/?>/,
-			'attr-name': {
-				pattern: /[^\s>\/]+/,
-				inside: {
-					'namespace': /^[^\s>\/:]+:/
-				}
-			}
+  'comment': {
+    pattern: /<!--(?:(?!<!--)[\s\S])*?-->/,
+    greedy: true
+  },
+  'prolog': {
+    pattern: /<\?[\s\S]+?\?>/,
+    greedy: true
+  },
+  'doctype': {
+    // https://www.w3.org/TR/xml/#NT-doctypedecl
+    pattern: /<!DOCTYPE(?:[^>"'[\]]|"[^"]*"|'[^']*')+(?:\[(?:[^<"'\]]|"[^"]*"|'[^']*'|<(?!!--)|<!--(?:[^-]|-(?!->))*-->)*\]\s*)?>/i,
+    greedy: true,
+    inside: {
+      'internal-subset': {
+        pattern: /(^[^\[]*\[)[\s\S]+(?=\]>$)/,
+        lookbehind: true,
+        greedy: true,
+        inside: null // see below
+      },
+      'string': {
+        pattern: /"[^"]*"|'[^']*'/,
+        greedy: true
+      },
+      'punctuation': /^<!|>$|[[\]]/,
+      'doctype-tag': /^DOCTYPE/i,
+      'name': /[^\s<>'"]+/
+    }
+  },
+  'cdata': {
+    pattern: /<!\[CDATA\[[\s\S]*?\]\]>/i,
+    greedy: true
+  },
+  'tag': {
+    pattern: /<\/?(?!\d)[^\s>\/=$<%]+(?:\s(?:\s*[^\s>\/=]+(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s'">=]+(?=[\s>]))|(?=[\s/>])))+)?\s*\/?>/,
+    greedy: true,
+    inside: {
+      'tag': {
+        pattern: /^<\/?[^\s>\/]+/,
+        inside: {
+          'punctuation': /^<\/?/,
+          'namespace': /^[^\s>\/:]+:/
+        }
+      },
+      'special-attr': [],
+      'attr-value': {
+        pattern: /=\s*(?:"[^"]*"|'[^']*'|[^\s'">=]+)/,
+        inside: {
+          'punctuation': [
+            {
+              pattern: /^=/,
+              alias: 'attr-equals'
+            },
+            /"|'/
+          ]
+        }
+      },
+      'punctuation': /\/?>/,
+      'attr-name': {
+        pattern: /[^\s>\/]+/,
+        inside: {
+          'namespace': /^[^\s>\/:]+:/
+        }
+      }
 
-		}
-	},
-	'entity': [
-		{
-			pattern: /&[\da-z]{1,8};/i,
-			alias: 'named-entity'
-		},
-		/&#x?[\da-f]{1,8};/i
-	]
+    }
+  },
+  'entity': [
+    {
+      pattern: /&[\da-z]{1,8};/i,
+      alias: 'named-entity'
+    },
+    /&#x?[\da-f]{1,8};/i
+  ]
 };
 
 Prism.languages.markup['tag'].inside['attr-value'].inside['entity'] =
-	Prism.languages.markup['entity'];
+  Prism.languages.markup['entity'];
 Prism.languages.markup['doctype'].inside['internal-subset'].inside = Prism.languages.markup;
 
 // Plugin to make entity title show the real entity, idea by Roman Komarov
 Prism.hooks.add('wrap', function (env) {
 
-	if (env.type === 'entity') {
-		env.attributes['title'] = env.content.replace(/&amp;/, '&');
-	}
+  if (env.type === 'entity') {
+    env.attributes['title'] = env.content.replace(/&amp;/, '&');
+  }
 });
 
 Object.defineProperty(Prism.languages.markup.tag, 'addInlined', {
-	/**
-	 * Adds an inlined language to markup.
-	 *
-	 * An example of an inlined language is CSS with `<style>` tags.
-	 *
-	 * @param {string} tagName The name of the tag that contains the inlined language. This name will be treated as
-	 * case insensitive.
-	 * @param {string} lang The language key.
-	 * @example
-	 * addInlined('style', 'css');
-	 */
-	value: function addInlined(tagName, lang) {
-		var includedCdataInside = {};
-		includedCdataInside['language-' + lang] = {
-			pattern: /(^<!\[CDATA\[)[\s\S]+?(?=\]\]>$)/i,
-			lookbehind: true,
-			inside: Prism.languages[lang]
-		};
-		includedCdataInside['cdata'] = /^<!\[CDATA\[|\]\]>$/i;
+  /**
+   * Adds an inlined language to markup.
+   *
+   * An example of an inlined language is CSS with `<style>` tags.
+   *
+   * @param {string} tagName The name of the tag that contains the inlined language. This name will be treated as
+   * case insensitive.
+   * @param {string} lang The language key.
+   * @example
+   * addInlined('style', 'css');
+   */
+  value: function addInlined(tagName, lang) {
+    var includedCdataInside = {};
+    includedCdataInside['language-' + lang] = {
+      pattern: /(^<!\[CDATA\[)[\s\S]+?(?=\]\]>$)/i,
+      lookbehind: true,
+      inside: Prism.languages[lang]
+    };
+    includedCdataInside['cdata'] = /^<!\[CDATA\[|\]\]>$/i;
 
-		var inside = {
-			'included-cdata': {
-				pattern: /<!\[CDATA\[[\s\S]*?\]\]>/i,
-				inside: includedCdataInside
-			}
-		};
-		inside['language-' + lang] = {
-			pattern: /[\s\S]+/,
-			inside: Prism.languages[lang]
-		};
+    var inside = {
+      'included-cdata': {
+        pattern: /<!\[CDATA\[[\s\S]*?\]\]>/i,
+        inside: includedCdataInside
+      }
+    };
+    inside['language-' + lang] = {
+      pattern: /[\s\S]+/,
+      inside: Prism.languages[lang]
+    };
 
-		var def = {};
-		def[tagName] = {
-			pattern: RegExp(/(<__[^>]*>)(?:<!\[CDATA\[(?:[^\]]|\](?!\]>))*\]\]>|(?!<!\[CDATA\[)[\s\S])*?(?=<\/__>)/.source.replace(/__/g, function () { return tagName; }), 'i'),
-			lookbehind: true,
-			greedy: true,
-			inside: inside
-		};
+    var def = {};
+    def[tagName] = {
+      pattern: RegExp(/(<__[^>]*>)(?:<!\[CDATA\[(?:[^\]]|\](?!\]>))*\]\]>|(?!<!\[CDATA\[)[\s\S])*?(?=<\/__>)/.source.replace(/__/g, function () { return tagName; }), 'i'),
+      lookbehind: true,
+      greedy: true,
+      inside: inside
+    };
 
-		Prism.languages.insertBefore('markup', 'cdata', def);
-	}
+    Prism.languages.insertBefore('markup', 'cdata', def);
+  }
 });
 Object.defineProperty(Prism.languages.markup.tag, 'addAttribute', {
-	/**
-	 * Adds an pattern to highlight languages embedded in HTML attributes.
-	 *
-	 * An example of an inlined language is CSS with `style` attributes.
-	 *
-	 * @param {string} attrName The name of the tag that contains the inlined language. This name will be treated as
-	 * case insensitive.
-	 * @param {string} lang The language key.
-	 * @example
-	 * addAttribute('style', 'css');
-	 */
-	value: function (attrName, lang) {
-		Prism.languages.markup.tag.inside['special-attr'].push({
-			pattern: RegExp(
-				/(^|["'\s])/.source + '(?:' + attrName + ')' + /\s*=\s*(?:"[^"]*"|'[^']*'|[^\s'">=]+(?=[\s>]))/.source,
-				'i'
-			),
-			lookbehind: true,
-			inside: {
-				'attr-name': /^[^\s=]+/,
-				'attr-value': {
-					pattern: /=[\s\S]+/,
-					inside: {
-						'value': {
-							pattern: /(^=\s*(["']|(?!["'])))\S[\s\S]*(?=\2$)/,
-							lookbehind: true,
-							alias: [lang, 'language-' + lang],
-							inside: Prism.languages[lang]
-						},
-						'punctuation': [
-							{
-								pattern: /^=/,
-								alias: 'attr-equals'
-							},
-							/"|'/
-						]
-					}
-				}
-			}
-		});
-	}
+  /**
+   * Adds an pattern to highlight languages embedded in HTML attributes.
+   *
+   * An example of an inlined language is CSS with `style` attributes.
+   *
+   * @param {string} attrName The name of the tag that contains the inlined language. This name will be treated as
+   * case insensitive.
+   * @param {string} lang The language key.
+   * @example
+   * addAttribute('style', 'css');
+   */
+  value: function (attrName, lang) {
+    Prism.languages.markup.tag.inside['special-attr'].push({
+      pattern: RegExp(
+        /(^|["'\s])/.source + '(?:' + attrName + ')' + /\s*=\s*(?:"[^"]*"|'[^']*'|[^\s'">=]+(?=[\s>]))/.source,
+        'i'
+      ),
+      lookbehind: true,
+      inside: {
+        'attr-name': /^[^\s=]+/,
+        'attr-value': {
+          pattern: /=[\s\S]+/,
+          inside: {
+            'value': {
+              pattern: /(^=\s*(["']|(?!["'])))\S[\s\S]*(?=\2$)/,
+              lookbehind: true,
+              alias: [lang, 'language-' + lang],
+              inside: Prism.languages[lang]
+            },
+            'punctuation': [
+              {
+                pattern: /^=/,
+                alias: 'attr-equals'
+              },
+              /"|'/
+            ]
+          }
+        }
+      }
+    });
+  }
 });
 
 Prism.languages.html = Prism.languages.markup;
@@ -1399,484 +1447,377 @@ Prism.languages.rss = Prism.languages.xml;
 
 (function (Prism) {
 
-	var string = /(?:"(?:\\(?:\r\n|[\s\S])|[^"\\\r\n])*"|'(?:\\(?:\r\n|[\s\S])|[^'\\\r\n])*')/;
+  var string = /(?:"(?:\\(?:\r\n|[\s\S])|[^"\\\r\n])*"|'(?:\\(?:\r\n|[\s\S])|[^'\\\r\n])*')/;
 
-	Prism.languages.css = {
-		'comment': /\/\*[\s\S]*?\*\//,
-		'atrule': {
-			pattern: /@[\w-](?:[^;{\s]|\s+(?![\s{]))*(?:;|(?=\s*\{))/,
-			inside: {
-				'rule': /^@[\w-]+/,
-				'selector-function-argument': {
-					pattern: /(\bselector\s*\(\s*(?![\s)]))(?:[^()\s]|\s+(?![\s)])|\((?:[^()]|\([^()]*\))*\))+(?=\s*\))/,
-					lookbehind: true,
-					alias: 'selector'
-				},
-				'keyword': {
-					pattern: /(^|[^\w-])(?:and|not|only|or)(?![\w-])/,
-					lookbehind: true
-				}
-				// See rest below
-			}
-		},
-		'url': {
-			// https://drafts.csswg.org/css-values-3/#urls
-			pattern: RegExp('\\burl\\((?:' + string.source + '|' + /(?:[^\\\r\n()"']|\\[\s\S])*/.source + ')\\)', 'i'),
-			greedy: true,
-			inside: {
-				'function': /^url/i,
-				'punctuation': /^\(|\)$/,
-				'string': {
-					pattern: RegExp('^' + string.source + '$'),
-					alias: 'url'
-				}
-			}
-		},
-		'selector': {
-			pattern: RegExp('(^|[{}\\s])[^{}\\s](?:[^{};"\'\\s]|\\s+(?![\\s{])|' + string.source + ')*(?=\\s*\\{)'),
-			lookbehind: true
-		},
-		'string': {
-			pattern: string,
-			greedy: true
-		},
-		'property': {
-			pattern: /(^|[^-\w\xA0-\uFFFF])(?!\s)[-_a-z\xA0-\uFFFF](?:(?!\s)[-\w\xA0-\uFFFF])*(?=\s*:)/i,
-			lookbehind: true
-		},
-		'important': /!important\b/i,
-		'function': {
-			pattern: /(^|[^-a-z0-9])[-a-z0-9]+(?=\()/i,
-			lookbehind: true
-		},
-		'punctuation': /[(){};:,]/
-	};
+  Prism.languages.css = {
+    'comment': /\/\*[\s\S]*?\*\//,
+    'atrule': {
+      pattern: /@[\w-](?:[^;{\s]|\s+(?![\s{]))*(?:;|(?=\s*\{))/,
+      inside: {
+        'rule': /^@[\w-]+/,
+        'selector-function-argument': {
+          pattern: /(\bselector\s*\(\s*(?![\s)]))(?:[^()\s]|\s+(?![\s)])|\((?:[^()]|\([^()]*\))*\))+(?=\s*\))/,
+          lookbehind: true,
+          alias: 'selector'
+        },
+        'keyword': {
+          pattern: /(^|[^\w-])(?:and|not|only|or)(?![\w-])/,
+          lookbehind: true
+        }
+        // See rest below
+      }
+    },
+    'url': {
+      // https://drafts.csswg.org/css-values-3/#urls
+      pattern: RegExp('\\burl\\((?:' + string.source + '|' + /(?:[^\\\r\n()"']|\\[\s\S])*/.source + ')\\)', 'i'),
+      greedy: true,
+      inside: {
+        'function': /^url/i,
+        'punctuation': /^\(|\)$/,
+        'string': {
+          pattern: RegExp('^' + string.source + '$'),
+          alias: 'url'
+        }
+      }
+    },
+    'selector': {
+      pattern: RegExp('(^|[{}\\s])[^{}\\s](?:[^{};"\'\\s]|\\s+(?![\\s{])|' + string.source + ')*(?=\\s*\\{)'),
+      lookbehind: true
+    },
+    'string': {
+      pattern: string,
+      greedy: true
+    },
+    'property': {
+      pattern: /(^|[^-\w\xA0-\uFFFF])(?!\s)[-_a-z\xA0-\uFFFF](?:(?!\s)[-\w\xA0-\uFFFF])*(?=\s*:)/i,
+      lookbehind: true
+    },
+    'important': /!important\b/i,
+    'function': {
+      pattern: /(^|[^-a-z0-9])[-a-z0-9]+(?=\()/i,
+      lookbehind: true
+    },
+    'punctuation': /[(){};:,]/
+  };
 
-	Prism.languages.css['atrule'].inside.rest = Prism.languages.css;
+  Prism.languages.css['atrule'].inside.rest = Prism.languages.css;
 
-	var markup = Prism.languages.markup;
-	if (markup) {
-		markup.tag.addInlined('style', 'css');
-		markup.tag.addAttribute('style', 'css');
-	}
+  var markup = Prism.languages.markup;
+  if (markup) {
+    markup.tag.addInlined('style', 'css');
+    markup.tag.addAttribute('style', 'css');
+  }
 
 }(Prism));
 
 (function (Prism) {
 
-	var string = /("|')(?:\\(?:\r\n|[\s\S])|(?!\1)[^\\\r\n])*\1/;
-	var selectorInside;
+  var string = /("|')(?:\\(?:\r\n|[\s\S])|(?!\1)[^\\\r\n])*\1/;
+  var selectorInside;
 
-	Prism.languages.css.selector = {
-		pattern: Prism.languages.css.selector.pattern,
-		lookbehind: true,
-		inside: selectorInside = {
-			'pseudo-element': /:(?:after|before|first-letter|first-line|selection)|::[-\w]+/,
-			'pseudo-class': /:[-\w]+/,
-			'class': /\.[-\w]+/,
-			'id': /#[-\w]+/,
-			'attribute': {
-				pattern: RegExp('\\[(?:[^[\\]"\']|' + string.source + ')*\\]'),
-				greedy: true,
-				inside: {
-					'punctuation': /^\[|\]$/,
-					'case-sensitivity': {
-						pattern: /(\s)[si]$/i,
-						lookbehind: true,
-						alias: 'keyword'
-					},
-					'namespace': {
-						pattern: /^(\s*)(?:(?!\s)[-*\w\xA0-\uFFFF])*\|(?!=)/,
-						lookbehind: true,
-						inside: {
-							'punctuation': /\|$/
-						}
-					},
-					'attr-name': {
-						pattern: /^(\s*)(?:(?!\s)[-\w\xA0-\uFFFF])+/,
-						lookbehind: true
-					},
-					'attr-value': [
-						string,
-						{
-							pattern: /(=\s*)(?:(?!\s)[-\w\xA0-\uFFFF])+(?=\s*$)/,
-							lookbehind: true
-						}
-					],
-					'operator': /[|~*^$]?=/
-				}
-			},
-			'n-th': [
-				{
-					pattern: /(\(\s*)[+-]?\d*[\dn](?:\s*[+-]\s*\d+)?(?=\s*\))/,
-					lookbehind: true,
-					inside: {
-						'number': /[\dn]+/,
-						'operator': /[+-]/
-					}
-				},
-				{
-					pattern: /(\(\s*)(?:even|odd)(?=\s*\))/i,
-					lookbehind: true
-				}
-			],
-			'combinator': />|\+|~|\|\|/,
+  Prism.languages.css.selector = {
+    pattern: Prism.languages.css.selector.pattern,
+    lookbehind: true,
+    inside: selectorInside = {
+      'pseudo-element': /:(?:after|before|first-letter|first-line|selection)|::[-\w]+/,
+      'pseudo-class': /:[-\w]+/,
+      'class': /\.[-\w]+/,
+      'id': /#[-\w]+/,
+      'attribute': {
+        pattern: RegExp('\\[(?:[^[\\]"\']|' + string.source + ')*\\]'),
+        greedy: true,
+        inside: {
+          'punctuation': /^\[|\]$/,
+          'case-sensitivity': {
+            pattern: /(\s)[si]$/i,
+            lookbehind: true,
+            alias: 'keyword'
+          },
+          'namespace': {
+            pattern: /^(\s*)(?:(?!\s)[-*\w\xA0-\uFFFF])*\|(?!=)/,
+            lookbehind: true,
+            inside: {
+              'punctuation': /\|$/
+            }
+          },
+          'attr-name': {
+            pattern: /^(\s*)(?:(?!\s)[-\w\xA0-\uFFFF])+/,
+            lookbehind: true
+          },
+          'attr-value': [
+            string,
+            {
+              pattern: /(=\s*)(?:(?!\s)[-\w\xA0-\uFFFF])+(?=\s*$)/,
+              lookbehind: true
+            }
+          ],
+          'operator': /[|~*^$]?=/
+        }
+      },
+      'n-th': [
+        {
+          pattern: /(\(\s*)[+-]?\d*[\dn](?:\s*[+-]\s*\d+)?(?=\s*\))/,
+          lookbehind: true,
+          inside: {
+            'number': /[\dn]+/,
+            'operator': /[+-]/
+          }
+        },
+        {
+          pattern: /(\(\s*)(?:even|odd)(?=\s*\))/i,
+          lookbehind: true
+        }
+      ],
+      'combinator': />|\+|~|\|\|/,
 
-			// the `tag` token has been existed and removed.
-			// because we can't find a perfect tokenize to match it.
-			// if you want to add it, please read https://github.com/PrismJS/prism/pull/2373 first.
+      // the `tag` token has been existed and removed.
+      // because we can't find a perfect tokenize to match it.
+      // if you want to add it, please read https://github.com/PrismJS/prism/pull/2373 first.
 
-			'punctuation': /[(),]/,
-		}
-	};
+      'punctuation': /[(),]/,
+    }
+  };
 
-	Prism.languages.css['atrule'].inside['selector-function-argument'].inside = selectorInside;
+  Prism.languages.css['atrule'].inside['selector-function-argument'].inside = selectorInside;
 
-	Prism.languages.insertBefore('css', 'property', {
-		'variable': {
-			pattern: /(^|[^-\w\xA0-\uFFFF])--(?!\s)[-_a-z\xA0-\uFFFF](?:(?!\s)[-\w\xA0-\uFFFF])*/i,
-			lookbehind: true
-		}
-	});
+  Prism.languages.insertBefore('css', 'property', {
+    'variable': {
+      pattern: /(^|[^-\w\xA0-\uFFFF])--(?!\s)[-_a-z\xA0-\uFFFF](?:(?!\s)[-\w\xA0-\uFFFF])*/i,
+      lookbehind: true
+    }
+  });
 
-	var unit = {
-		pattern: /(\b\d+)(?:%|[a-z]+(?![\w-]))/,
-		lookbehind: true
-	};
-	// 123 -123 .123 -.123 12.3 -12.3
-	var number = {
-		pattern: /(^|[^\w.-])-?(?:\d+(?:\.\d+)?|\.\d+)/,
-		lookbehind: true
-	};
+  var unit = {
+    pattern: /(\b\d+)(?:%|[a-z]+(?![\w-]))/,
+    lookbehind: true
+  };
+  // 123 -123 .123 -.123 12.3 -12.3
+  var number = {
+    pattern: /(^|[^\w.-])-?(?:\d+(?:\.\d+)?|\.\d+)/,
+    lookbehind: true
+  };
 
-	Prism.languages.insertBefore('css', 'function', {
-		'operator': {
-			pattern: /(\s)[+\-*\/](?=\s)/,
-			lookbehind: true
-		},
-		// CAREFUL!
-		// Previewers and Inline color use hexcode and color.
-		'hexcode': {
-			pattern: /\B#[\da-f]{3,8}\b/i,
-			alias: 'color'
-		},
-		'color': [
-			{
-				pattern: /(^|[^\w-])(?:AliceBlue|AntiqueWhite|Aqua|Aquamarine|Azure|Beige|Bisque|Black|BlanchedAlmond|Blue|BlueViolet|Brown|BurlyWood|CadetBlue|Chartreuse|Chocolate|Coral|CornflowerBlue|Cornsilk|Crimson|Cyan|DarkBlue|DarkCyan|DarkGoldenRod|DarkGr[ae]y|DarkGreen|DarkKhaki|DarkMagenta|DarkOliveGreen|DarkOrange|DarkOrchid|DarkRed|DarkSalmon|DarkSeaGreen|DarkSlateBlue|DarkSlateGr[ae]y|DarkTurquoise|DarkViolet|DeepPink|DeepSkyBlue|DimGr[ae]y|DodgerBlue|FireBrick|FloralWhite|ForestGreen|Fuchsia|Gainsboro|GhostWhite|Gold|GoldenRod|Gr[ae]y|Green|GreenYellow|HoneyDew|HotPink|IndianRed|Indigo|Ivory|Khaki|Lavender|LavenderBlush|LawnGreen|LemonChiffon|LightBlue|LightCoral|LightCyan|LightGoldenRodYellow|LightGr[ae]y|LightGreen|LightPink|LightSalmon|LightSeaGreen|LightSkyBlue|LightSlateGr[ae]y|LightSteelBlue|LightYellow|Lime|LimeGreen|Linen|Magenta|Maroon|MediumAquaMarine|MediumBlue|MediumOrchid|MediumPurple|MediumSeaGreen|MediumSlateBlue|MediumSpringGreen|MediumTurquoise|MediumVioletRed|MidnightBlue|MintCream|MistyRose|Moccasin|NavajoWhite|Navy|OldLace|Olive|OliveDrab|Orange|OrangeRed|Orchid|PaleGoldenRod|PaleGreen|PaleTurquoise|PaleVioletRed|PapayaWhip|PeachPuff|Peru|Pink|Plum|PowderBlue|Purple|Red|RosyBrown|RoyalBlue|SaddleBrown|Salmon|SandyBrown|SeaGreen|SeaShell|Sienna|Silver|SkyBlue|SlateBlue|SlateGr[ae]y|Snow|SpringGreen|SteelBlue|Tan|Teal|Thistle|Tomato|Transparent|Turquoise|Violet|Wheat|White|WhiteSmoke|Yellow|YellowGreen)(?![\w-])/i,
-				lookbehind: true
-			},
-			{
-				pattern: /\b(?:rgb|hsl)\(\s*\d{1,3}\s*,\s*\d{1,3}%?\s*,\s*\d{1,3}%?\s*\)\B|\b(?:rgb|hsl)a\(\s*\d{1,3}\s*,\s*\d{1,3}%?\s*,\s*\d{1,3}%?\s*,\s*(?:0|0?\.\d+|1)\s*\)\B/i,
-				inside: {
-					'unit': unit,
-					'number': number,
-					'function': /[\w-]+(?=\()/,
-					'punctuation': /[(),]/
-				}
-			}
-		],
-		// it's important that there is no boundary assertion after the hex digits
-		'entity': /\\[\da-f]{1,8}/i,
-		'unit': unit,
-		'number': number
-	});
+  Prism.languages.insertBefore('css', 'function', {
+    'operator': {
+      pattern: /(\s)[+\-*\/](?=\s)/,
+      lookbehind: true
+    },
+    // CAREFUL!
+    // Previewers and Inline color use hexcode and color.
+    'hexcode': {
+      pattern: /\B#[\da-f]{3,8}\b/i,
+      alias: 'color'
+    },
+    'color': [
+      {
+        pattern: /(^|[^\w-])(?:AliceBlue|AntiqueWhite|Aqua|Aquamarine|Azure|Beige|Bisque|Black|BlanchedAlmond|Blue|BlueViolet|Brown|BurlyWood|CadetBlue|Chartreuse|Chocolate|Coral|CornflowerBlue|Cornsilk|Crimson|Cyan|DarkBlue|DarkCyan|DarkGoldenRod|DarkGr[ae]y|DarkGreen|DarkKhaki|DarkMagenta|DarkOliveGreen|DarkOrange|DarkOrchid|DarkRed|DarkSalmon|DarkSeaGreen|DarkSlateBlue|DarkSlateGr[ae]y|DarkTurquoise|DarkViolet|DeepPink|DeepSkyBlue|DimGr[ae]y|DodgerBlue|FireBrick|FloralWhite|ForestGreen|Fuchsia|Gainsboro|GhostWhite|Gold|GoldenRod|Gr[ae]y|Green|GreenYellow|HoneyDew|HotPink|IndianRed|Indigo|Ivory|Khaki|Lavender|LavenderBlush|LawnGreen|LemonChiffon|LightBlue|LightCoral|LightCyan|LightGoldenRodYellow|LightGr[ae]y|LightGreen|LightPink|LightSalmon|LightSeaGreen|LightSkyBlue|LightSlateGr[ae]y|LightSteelBlue|LightYellow|Lime|LimeGreen|Linen|Magenta|Maroon|MediumAquaMarine|MediumBlue|MediumOrchid|MediumPurple|MediumSeaGreen|MediumSlateBlue|MediumSpringGreen|MediumTurquoise|MediumVioletRed|MidnightBlue|MintCream|MistyRose|Moccasin|NavajoWhite|Navy|OldLace|Olive|OliveDrab|Orange|OrangeRed|Orchid|PaleGoldenRod|PaleGreen|PaleTurquoise|PaleVioletRed|PapayaWhip|PeachPuff|Peru|Pink|Plum|PowderBlue|Purple|Red|RosyBrown|RoyalBlue|SaddleBrown|Salmon|SandyBrown|SeaGreen|SeaShell|Sienna|Silver|SkyBlue|SlateBlue|SlateGr[ae]y|Snow|SpringGreen|SteelBlue|Tan|Teal|Thistle|Tomato|Transparent|Turquoise|Violet|Wheat|White|WhiteSmoke|Yellow|YellowGreen)(?![\w-])/i,
+        lookbehind: true
+      },
+      {
+        pattern: /\b(?:hsl|rgb)\(\s*\d{1,3}\s*,\s*\d{1,3}%?\s*,\s*\d{1,3}%?\s*\)\B|\b(?:hsl|rgb)a\(\s*\d{1,3}\s*,\s*\d{1,3}%?\s*,\s*\d{1,3}%?\s*,\s*(?:0|0?\.\d+|1)\s*\)\B/i,
+        inside: {
+          'unit': unit,
+          'number': number,
+          'function': /[\w-]+(?=\()/,
+          'punctuation': /[(),]/
+        }
+      }
+    ],
+    // it's important that there is no boundary assertion after the hex digits
+    'entity': /\\[\da-f]{1,8}/i,
+    'unit': unit,
+    'number': number
+  });
 
 }(Prism));
 
 (function () {
 
-	if (typeof Prism === 'undefined' || typeof document === 'undefined') {
-		return;
-	}
+  if (typeof Prism === 'undefined' || typeof document === 'undefined') {
+    return;
+  }
 
-	// Copied from the markup language definition
-	var HTML_TAG = /<\/?(?!\d)[^\s>\/=$<%]+(?:\s(?:\s*[^\s>\/=]+(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s'">=]+(?=[\s>]))|(?=[\s/>])))+)?\s*\/?>/g;
+  function mapClassName(name) {
+    var customClass = Prism.plugins.customClass;
+    if (customClass) {
+      return customClass.apply(name, 'none');
+    } else {
+      return name;
+    }
+  }
 
-	// a regex to validate hexadecimal colors
-	var HEX_COLOR = /^#?((?:[\da-f]){3,4}|(?:[\da-f]{2}){3,4})$/i;
+  var PARTNER = {
+    '(': ')',
+    '[': ']',
+    '{': '}',
+  };
 
-	/**
-	 * Parses the given hexadecimal representation and returns the parsed RGBA color.
-	 *
-	 * If the format of the given string is invalid, `undefined` will be returned.
-	 * Valid formats are: `RGB`, `RGBA`, `RRGGBB`, and `RRGGBBAA`.
-	 *
-	 * Hexadecimal colors are parsed because they are not fully supported by older browsers, so converting them to
-	 * `rgba` functions improves browser compatibility.
-	 *
-	 * @param {string} hex
-	 * @returns {string | undefined}
-	 */
-	function parseHexColor(hex) {
-		var match = HEX_COLOR.exec(hex);
-		if (!match) {
-			return undefined;
-		}
-		hex = match[1]; // removes the leading "#"
+  // The names for brace types.
+  // These names have two purposes: 1) they can be used for styling and 2) they are used to pair braces. Only braces
+  // of the same type are paired.
+  var NAMES = {
+    '(': 'brace-round',
+    '[': 'brace-square',
+    '{': 'brace-curly',
+  };
 
-		// the width and number of channels
-		var channelWidth = hex.length >= 6 ? 2 : 1;
-		var channelCount = hex.length / channelWidth;
+  // A map for brace aliases.
+  // This is useful for when some braces have a prefix/suffix as part of the punctuation token.
+  var BRACE_ALIAS_MAP = {
+    '${': '{', // JS template punctuation (e.g. `foo ${bar + 1}`)
+  };
 
-		// the scale used to normalize 4bit and 8bit values
-		var scale = channelWidth == 1 ? 1 / 15 : 1 / 255;
+  var LEVEL_WARP = 12;
 
-		// normalized RGBA channels
-		var channels = [];
-		for (var i = 0; i < channelCount; i++) {
-			var int = parseInt(hex.substr(i * channelWidth, channelWidth), 16);
-			channels.push(int * scale);
-		}
-		if (channelCount == 3) {
-			channels.push(1); // add alpha of 100%
-		}
+  var pairIdCounter = 0;
 
-		// output
-		var rgb = channels.slice(0, 3).map(function (x) {
-			return String(Math.round(x * 255));
-		}).join(',');
-		var alpha = String(Number(channels[3].toFixed(3))); // easy way to round 3 decimal places
+  var BRACE_ID_PATTERN = /^(pair-\d+-)(close|open)$/;
 
-		return 'rgba(' + rgb + ',' + alpha + ')';
-	}
+  /**
+   * Returns the brace partner given one brace of a brace pair.
+   *
+   * @param {HTMLElement} brace
+   * @returns {HTMLElement}
+   */
+  function getPartnerBrace(brace) {
+    var match = BRACE_ID_PATTERN.exec(brace.id);
+    return document.querySelector('#' + match[1] + (match[2] == 'open' ? 'close' : 'open'));
+  }
 
-	/**
-	 * Validates the given Color using the current browser's internal implementation.
-	 *
-	 * @param {string} color
-	 * @returns {string | undefined}
-	 */
-	function validateColor(color) {
-		var s = new Option().style;
-		s.color = color;
-		return s.color ? color : undefined;
-	}
+  /**
+   * @this {HTMLElement}
+   */
+  function hoverBrace() {
+    if (!Prism.util.isActive(this, 'brace-hover', true)) {
+      return;
+    }
 
-	/**
-	 * An array of function which parse a given string representation of a color.
-	 *
-	 * These parser serve as validators and as a layer of compatibility to support color formats which the browser
-	 * might not support natively.
-	 *
-	 * @type {((value: string) => (string|undefined))[]}
-	 */
-	var parsers = [
-		parseHexColor,
-		validateColor
-	];
+    [this, getPartnerBrace(this)].forEach(function (e) {
+      e.classList.add(mapClassName('brace-hover'));
+    });
+  }
+  /**
+   * @this {HTMLElement}
+   */
+  function leaveBrace() {
+    [this, getPartnerBrace(this)].forEach(function (e) {
+      e.classList.remove(mapClassName('brace-hover'));
+    });
+  }
+  /**
+   * @this {HTMLElement}
+   */
+  function clickBrace() {
+    if (!Prism.util.isActive(this, 'brace-select', true)) {
+      return;
+    }
 
+    [this, getPartnerBrace(this)].forEach(function (e) {
+      e.classList.add(mapClassName('brace-selected'));
+    });
+  }
 
-	Prism.hooks.add('wrap', function (env) {
-		if (env.type === 'color' || env.classes.indexOf('color') >= 0) {
-			var content = env.content;
+  Prism.hooks.add('complete', function (env) {
 
-			// remove all HTML tags inside
-			var rawText = content.split(HTML_TAG).join('');
+    /** @type {HTMLElement} */
+    var code = env.element;
+    var pre = code.parentElement;
 
-			var color;
-			for (var i = 0, l = parsers.length; i < l && !color; i++) {
-				color = parsers[i](rawText);
-			}
+    if (!pre || pre.tagName != 'PRE') {
+      return;
+    }
 
-			if (!color) {
-				return;
-			}
+    // find the braces to match
+    /** @type {string[]} */
+    var toMatch = [];
+    if (Prism.util.isActive(code, 'match-braces')) {
+      toMatch.push('(', '[', '{');
+    }
 
-			var previewElement = '<span class="inline-color-wrapper"><span class="inline-color" style="background-color:' + color + ';"></span></span>';
-			env.content = previewElement + content;
-		}
-	});
+    if (toMatch.length == 0) {
+      // nothing to match
+      return;
+    }
 
-}());
+    if (!pre.__listenerAdded) {
+      // code blocks might be highlighted more than once
+      pre.addEventListener('mousedown', function removeBraceSelected() {
+        // the code element might have been replaced
+        var code = pre.querySelector('code');
+        var className = mapClassName('brace-selected');
+        Array.prototype.slice.call(code.querySelectorAll('.' + className)).forEach(function (e) {
+          e.classList.remove(className);
+        });
+      });
+      Object.defineProperty(pre, '__listenerAdded', { value: true });
+    }
 
-(function () {
+    /** @type {HTMLSpanElement[]} */
+    var punctuation = Array.prototype.slice.call(
+      code.querySelectorAll('span.' + mapClassName('token') + '.' + mapClassName('punctuation'))
+    );
 
-	if (typeof Prism === 'undefined' || typeof document === 'undefined') {
-		return;
-	}
+    /** @type {{ index: number, open: boolean, element: HTMLElement }[]} */
+    var allBraces = [];
 
-	function mapClassName(name) {
-		var customClass = Prism.plugins.customClass;
-		if (customClass) {
-			return customClass.apply(name, 'none');
-		} else {
-			return name;
-		}
-	}
+    toMatch.forEach(function (open) {
+      var close = PARTNER[open];
+      var name = mapClassName(NAMES[open]);
 
-	var PARTNER = {
-		'(': ')',
-		'[': ']',
-		'{': '}',
-	};
+      /** @type {[number, number][]} */
+      var pairs = [];
+      /** @type {number[]} */
+      var openStack = [];
 
-	// The names for brace types.
-	// These names have two purposes: 1) they can be used for styling and 2) they are used to pair braces. Only braces
-	// of the same type are paired.
-	var NAMES = {
-		'(': 'brace-round',
-		'[': 'brace-square',
-		'{': 'brace-curly',
-	};
+      for (var i = 0; i < punctuation.length; i++) {
+        var element = punctuation[i];
+        if (element.childElementCount == 0) {
+          var text = element.textContent;
+          text = BRACE_ALIAS_MAP[text] || text;
+          if (text === open) {
+            allBraces.push({ index: i, open: true, element: element });
+            element.classList.add(name);
+            element.classList.add(mapClassName('brace-open'));
+            openStack.push(i);
+          } else if (text === close) {
+            allBraces.push({ index: i, open: false, element: element });
+            element.classList.add(name);
+            element.classList.add(mapClassName('brace-close'));
+            if (openStack.length) {
+              pairs.push([i, openStack.pop()]);
+            }
+          }
+        }
+      }
 
-	// A map for brace aliases.
-	// This is useful for when some braces have a prefix/suffix as part of the punctuation token.
-	var BRACE_ALIAS_MAP = {
-		'${': '{', // JS template punctuation (e.g. `foo ${bar + 1}`)
-	};
+      pairs.forEach(function (pair) {
+        var pairId = 'pair-' + (pairIdCounter++) + '-';
 
-	var LEVEL_WARP = 12;
+        var opening = punctuation[pair[0]];
+        var closing = punctuation[pair[1]];
 
-	var pairIdCounter = 0;
+        opening.id = pairId + 'open';
+        closing.id = pairId + 'close';
 
-	var BRACE_ID_PATTERN = /^(pair-\d+-)(open|close)$/;
+        [opening, closing].forEach(function (e) {
+          e.addEventListener('mouseenter', hoverBrace);
+          e.addEventListener('mouseleave', leaveBrace);
+          e.addEventListener('click', clickBrace);
+        });
+      });
+    });
 
-	/**
-	 * Returns the brace partner given one brace of a brace pair.
-	 *
-	 * @param {HTMLElement} brace
-	 * @returns {HTMLElement}
-	 */
-	function getPartnerBrace(brace) {
-		var match = BRACE_ID_PATTERN.exec(brace.id);
-		return document.querySelector('#' + match[1] + (match[2] == 'open' ? 'close' : 'open'));
-	}
-
-	/**
-	 * @this {HTMLElement}
-	 */
-	function hoverBrace() {
-		if (!Prism.util.isActive(this, 'brace-hover', true)) {
-			return;
-		}
-
-		[this, getPartnerBrace(this)].forEach(function (e) {
-			e.classList.add(mapClassName('brace-hover'));
-		});
-	}
-	/**
-	 * @this {HTMLElement}
-	 */
-	function leaveBrace() {
-		[this, getPartnerBrace(this)].forEach(function (e) {
-			e.classList.remove(mapClassName('brace-hover'));
-		});
-	}
-	/**
-	 * @this {HTMLElement}
-	 */
-	function clickBrace() {
-		if (!Prism.util.isActive(this, 'brace-select', true)) {
-			return;
-		}
-
-		[this, getPartnerBrace(this)].forEach(function (e) {
-			e.classList.add(mapClassName('brace-selected'));
-		});
-	}
-
-	Prism.hooks.add('complete', function (env) {
-
-		/** @type {HTMLElement} */
-		var code = env.element;
-		var pre = code.parentElement;
-
-		if (!pre || pre.tagName != 'PRE') {
-			return;
-		}
-
-		// find the braces to match
-		/** @type {string[]} */
-		var toMatch = [];
-		if (Prism.util.isActive(code, 'match-braces')) {
-			toMatch.push('(', '[', '{');
-		}
-
-		if (toMatch.length == 0) {
-			// nothing to match
-			return;
-		}
-
-		if (!pre.__listenerAdded) {
-			// code blocks might be highlighted more than once
-			pre.addEventListener('mousedown', function removeBraceSelected() {
-				// the code element might have been replaced
-				var code = pre.querySelector('code');
-				var className = mapClassName('brace-selected');
-				Array.prototype.slice.call(code.querySelectorAll('.' + className)).forEach(function (e) {
-					e.classList.remove(className);
-				});
-			});
-			Object.defineProperty(pre, '__listenerAdded', { value: true });
-		}
-
-		/** @type {HTMLSpanElement[]} */
-		var punctuation = Array.prototype.slice.call(
-			code.querySelectorAll('span.' + mapClassName('token') + '.' + mapClassName('punctuation'))
-		);
-
-		/** @type {{ index: number, open: boolean, element: HTMLElement }[]} */
-		var allBraces = [];
-
-		toMatch.forEach(function (open) {
-			var close = PARTNER[open];
-			var name = mapClassName(NAMES[open]);
-
-			/** @type {[number, number][]} */
-			var pairs = [];
-			/** @type {number[]} */
-			var openStack = [];
-
-			for (var i = 0; i < punctuation.length; i++) {
-				var element = punctuation[i];
-				if (element.childElementCount == 0) {
-					var text = element.textContent;
-					text = BRACE_ALIAS_MAP[text] || text;
-					if (text === open) {
-						allBraces.push({ index: i, open: true, element: element });
-						element.classList.add(name);
-						element.classList.add(mapClassName('brace-open'));
-						openStack.push(i);
-					} else if (text === close) {
-						allBraces.push({ index: i, open: false, element: element });
-						element.classList.add(name);
-						element.classList.add(mapClassName('brace-close'));
-						if (openStack.length) {
-							pairs.push([i, openStack.pop()]);
-						}
-					}
-				}
-			}
-
-			pairs.forEach(function (pair) {
-				var pairId = 'pair-' + (pairIdCounter++) + '-';
-
-				var opening = punctuation[pair[0]];
-				var closing = punctuation[pair[1]];
-
-				opening.id = pairId + 'open';
-				closing.id = pairId + 'close';
-
-				[opening, closing].forEach(function (e) {
-					e.addEventListener('mouseenter', hoverBrace);
-					e.addEventListener('mouseleave', leaveBrace);
-					e.addEventListener('click', clickBrace);
-				});
-			});
-		});
-
-		var level = 0;
-		allBraces.sort(function (a, b) { return a.index - b.index; });
-		allBraces.forEach(function (brace) {
-			if (brace.open) {
-				brace.element.classList.add(mapClassName('brace-level-' + (level % LEVEL_WARP + 1)));
-				level++;
-			} else {
-				level = Math.max(0, level - 1);
-				brace.element.classList.add(mapClassName('brace-level-' + (level % LEVEL_WARP + 1)));
-			}
-		});
-	});
+    var level = 0;
+    allBraces.sort(function (a, b) { return a.index - b.index; });
+    allBraces.forEach(function (brace) {
+      if (brace.open) {
+        brace.element.classList.add(mapClassName('brace-level-' + (level % LEVEL_WARP + 1)));
+        level++;
+      } else {
+        level = Math.max(0, level - 1);
+        brace.element.classList.add(mapClassName('brace-level-' + (level % LEVEL_WARP + 1)));
+      }
+    });
+  });
 
 }());
-


### PR DESCRIPTION
The Prism styling is not applied to the user input directly (to avoid headaches), instead the user input itself is hidden and used to update an element with styling for display. This led to a problem when Prism inserted colour preview boxes ahead of colour names in its output, leading to the cursor (still displayed based on the <textarea>) getting out of sync with the output display.